### PR TITLE
Use safe ccall for scrypt foreign call

### DIFF
--- a/src/Tinfoil/KDF/Scrypt/Internal.hs
+++ b/src/Tinfoil/KDF/Scrypt/Internal.hs
@@ -100,7 +100,7 @@ scrypt (ScryptParams logN r p) (Entropy salt) (Credential pass) =
       bufPtr (fromIntegral bufLen)
     BS.packCStringLen (castPtr bufPtr, fromIntegral bufLen)
 
-foreign import ccall unsafe crypto_scrypt
+foreign import ccall safe crypto_scrypt
     :: Ptr Word8 -> CSize         -- password
     -> Ptr Word8 -> CSize         -- salt
     -> Word64 -> Word32 -> Word32 -- N, r, p


### PR DESCRIPTION
scrypt takes ages, so we should allow the RTS to preempt it so things
don't fall over when running with a single core.

/cc @markhibberd @nhibberd @jystic 
