### PR TITLE
Don't generate salt in `verifyNoCredential`

### DIFF
--- a/mafia
+++ b/mafia
@@ -67,11 +67,9 @@ exec_mafia () {
 
       # Create a temporary file in MAFIA_BIN so we can do an atomic copy/move dance.
       mkdir -p $MAFIA_BIN
-      MAFIA_PATH_TEMP=$(mktemp --tmpdir=$MAFIA_BIN $MAFIA_FILE-XXXXXX 2>/dev/null || TMPDIR=$MAFIA_BIN mktemp -t $MAFIA_FILE)
 
       clean_up () {
         rm -rf "$MAFIA_TEMP"
-        rm -f "$MAFIA_PATH_TEMP"
       }
 
       trap clean_up EXIT
@@ -87,9 +85,19 @@ exec_mafia () {
 
         bin/bootstrap ) || exit $?
 
+      MAFIA_PATH_TEMP=$(mktemp --tmpdir=$MAFIA_BIN $MAFIA_FILE-XXXXXX 2>/dev/null || TMPDIR=$MAFIA_BIN mktemp -t $MAFIA_FILE)
+
+      clean_up_temp () {
+        clean_up
+        rm -f "$MAFIA_PATH_TEMP"
+      }
+      trap clean_up_temp EXIT
+
       cp "$MAFIA_TEMP/mafia/.cabal-sandbox/bin/mafia" "$MAFIA_PATH_TEMP"
-      chmod +x "$MAFIA_PATH_TEMP"
+      chmod 755 "$MAFIA_PATH_TEMP"
       mv "$MAFIA_PATH_TEMP" "$MAFIA_PATH"
+
+      clean_up_temp
     }
 
     exec $MAFIA_PATH "$@"
@@ -110,4 +118,4 @@ case "$MODE" in
 upgrade) shift; run_upgrade "$@" ;;
 *) exec_mafia "$@"
 esac
-# Version: 92881411b204a00b11d8a26117bd9244fdb8e4d4
+# Version: ab0f6332f7846f001bbcc942760f6e0c6ece8b9e

--- a/src/Tinfoil.hs
+++ b/src/Tinfoil.hs
@@ -1,4 +1,9 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE OverloadedStrings #-}
-module Tinfoil where
+module Tinfoil(
+    module X
+  ) where
+
+import           Tinfoil.Data as X
+import           Tinfoil.KDF as X

--- a/src/Tinfoil/KDF/Scrypt.hs
+++ b/src/Tinfoil/KDF/Scrypt.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Tinfoil.KDF.Scrypt(
-    defaultParams
+    ScryptParams
+  , defaultParams
   , hashCredential
   , scryptMCFPrefix
   , verifyCredential

--- a/src/Tinfoil/KDF/Scrypt.hs
+++ b/src/Tinfoil/KDF/Scrypt.hs
@@ -9,6 +9,8 @@ module Tinfoil.KDF.Scrypt(
   , verifyNoCredential
 ) where
 
+import qualified Data.ByteString as BS
+
 import           P
 
 import           System.IO
@@ -34,15 +36,15 @@ salt = entropy 32
 
 verifyNoCredential :: ScryptParams -> Credential -> IO Verified
 verifyNoCredential p c = do
-  e <- salt
   h <- scrypt p e c
   void $ h `safeEq` ""
   pure NotVerified
+  where
+    e = Entropy $ BS.replicate 32 0x00
 
 verifyCredential :: CredentialHash -> Credential -> IO Verified
 verifyCredential ch c = case separate ch of
   Just (p, e, h) -> do
-    void salt -- timing consistency
     h' <- scrypt p e c
     r <- h' `safeEq` h
     if r


### PR DESCRIPTION
Four changes:

 - Don't generate a salt in `verifyNoCredential`, it results in a perceptible slowdown. No idea how I didn't pick this up before.
 - Bump `mafia`.
 - Export `ScryptParams` type (but not constructor) so clients can define their own `myScryptParams` rather than duplicating `Tinfoil.defaultParams` everywhere.
 - Export types and utility functions from root module for convenience.

Benchmarks before and after salt change:

```
∃ ~/tmp/tinfoil-bench-master kdf
benchmarking kdf/scrypt/hashCredential/defaultParams
time                 1.762 s    (1.698 s .. 1.836 s)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 1.779 s    (1.767 s .. 1.790 s)
std dev              19.36 ms   (0.0 s .. 19.80 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking kdf/scrypt/verifyNoCredential/defaultParams
time                 2.273 s    (1.802 s .. 2.587 s)
                     0.994 R²   (0.990 R² .. 1.000 R²)
mean                 2.457 s    (2.324 s .. 2.533 s)
std dev              118.8 ms   (0.0 s .. 131.2 ms)
variance introduced by outliers: 19% (moderately inflated)

∃ ~/tmp/tinfoil-bench-new kdf
benchmarking kdf/scrypt/hashCredential/defaultParams
time                 2.074 s    (1.752 s .. 2.809 s)
                     0.985 R²   (0.975 R² .. 1.000 R²)
mean                 1.854 s    (1.766 s .. 1.941 s)
std dev              150.2 ms   (0.0 s .. 150.6 ms)
variance introduced by outliers: 21% (moderately inflated)

benchmarking kdf/scrypt/verifyNoCredential/defaultParams
time                 1.958 s    (1.552 s .. 2.348 s)
                     0.995 R²   (0.980 R² .. 1.000 R²)
mean                 1.913 s    (1.838 s .. 1.970 s)
std dev              86.57 ms   (0.0 s .. 98.08 ms)
variance introduced by outliers: 19% (moderately inflated)
```