### PR TITLE
Support arbitrary bytes in credentials

### DIFF
--- a/src/Tinfoil/Data/KDF.hs
+++ b/src/Tinfoil/Data/KDF.hs
@@ -30,7 +30,7 @@ instance NFData CredentialHash
 
 newtype Credential =
   Credential {
-    unCredential :: Text
+    unCredential :: ByteString
   } deriving (Eq, Show, Generic)
 
 instance NFData Credential

--- a/src/Tinfoil/KDF/Scrypt/Internal.hs
+++ b/src/Tinfoil/KDF/Scrypt/Internal.hs
@@ -88,10 +88,9 @@ separate = go . BS.split (fromIntegral $ ord '|') . unCredentialHash
 -- run in IO.
 scrypt :: ScryptParams -> Entropy -> Credential -> IO ByteString
 scrypt (ScryptParams logN r p) (Entropy salt) (Credential pass) =
-  let pass'  = T.encodeUtf8 pass 
-      bufLen = 64 :: Int in
+  let bufLen = 64 :: Int in
   BS.useAsCStringLen salt $ \(saltPtr, saltLen) ->
-  BS.useAsCStringLen pass' $ \(passPtr, passLen) ->
+  BS.useAsCStringLen pass $ \(passPtr, passLen) ->
   allocaBytes (fromIntegral bufLen) $ \bufPtr -> do
     throwErrnoIfMinus1_ "crypto_scrypt" $ crypto_scrypt
       (castPtr passPtr) (fromIntegral passLen)

--- a/src/Tinfoil/Random.hs
+++ b/src/Tinfoil/Random.hs
@@ -12,6 +12,7 @@ import           Data.List ((\\))
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 
 import           P
 
@@ -34,7 +35,7 @@ entropy = fmap Entropy . E.getEntropy
 randomCredential :: [Char] -> Int -> IO (Maybe Credential)
 randomCredential excluded n = case charset of
   [] -> pure Nothing
-  cs -> (Just . Credential . T.pack) <$> replicateM n (drawOnce $ NE.fromList cs)
+  cs -> (Just . Credential . T.encodeUtf8 . T.pack) <$> replicateM n (drawOnce $ NE.fromList cs)
   where
     charset = (NE.toList credentialCharSet) \\ excluded 
 

--- a/test/Test/IO/Tinfoil/KDF.hs
+++ b/test/Test/IO/Tinfoil/KDF.hs
@@ -31,4 +31,4 @@ prop_safeEq_negative (UniquePair a b) = testIO $ do
 
 return []
 tests :: IO Bool
-tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 5 } )
+tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 10 } )

--- a/test/Test/IO/Tinfoil/KDF/Scrypt.hs
+++ b/test/Test/IO/Tinfoil/KDF/Scrypt.hs
@@ -68,4 +68,4 @@ prop_testVector (TestVector c s p h) = testIO $ do
 
 return []
 tests :: IO Bool
-tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 5 } )
+tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 10 } )

--- a/test/Test/IO/Tinfoil/Random.hs
+++ b/test/Test/IO/Tinfoil/Random.hs
@@ -5,12 +5,14 @@
 
 module Test.IO.Tinfoil.Random where
 
+import qualified Data.ByteString as BS
 import           Data.Char (ord)
 import           Data.List (intersect)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import           Data.Maybe (fromJust)
-import qualified Data.Text                     as T
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 
 import           Disorder.Core.IO
 
@@ -27,12 +29,12 @@ import           Test.Tinfoil.Arbitrary
 prop_randomCredential_length :: Property
 prop_randomCredential_length = forAll ((,) <$> credentialLength <*> excludedChars) $ \(l, ex) -> testIO $ do
   c <- randomCredential ex l
-  pure $ (T.length . unCredential $ fromJust c) === l
+  pure $ (BS.length . unCredential $ fromJust c) === l
 
 prop_randomCredential_exclusion :: Property
 prop_randomCredential_exclusion = forAll ((,) <$> credentialLength <*> excludedChars) $ \(l, ex) -> testIO $ do
   c <- randomCredential ex l
-  pure $ (intersect (T.unpack . unCredential $ fromJust c) ex) === []
+  pure $ (intersect (T.unpack . T.decodeUtf8 . unCredential $ fromJust c) ex) === []
 
 prop_randomCredential_empty :: Property
 prop_randomCredential_empty = forAll credentialLength $ \l -> testIO $ do
@@ -42,7 +44,7 @@ prop_randomCredential_empty = forAll credentialLength $ \l -> testIO $ do
 prop_randomCredential_printable :: Property
 prop_randomCredential_printable = forAll credentialLength $ \l -> testIO $ do
   cr <- randomCredential [] l
-  pure $ all (\c -> ord c < 128 && ord c >= 32) (T.unpack . unCredential $ fromJust cr)
+  pure $ all (\c -> ord c < 128 && ord c >= 32) (T.unpack . T.decodeUtf8 . unCredential $ fromJust cr)
 
 prop_drawOnce_closure :: Property
 prop_drawOnce_closure = forAll arbitrary $ \(xs :: NonEmpty Int) -> testIO $ do

--- a/test/Test/Tinfoil/Arbitrary.hs
+++ b/test/Test/Tinfoil/Arbitrary.hs
@@ -4,6 +4,7 @@
 
 module Test.Tinfoil.Arbitrary where
 
+import qualified Data.ByteString as BS
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text.Encoding as T
@@ -14,7 +15,6 @@ import           P
 
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
-import           Test.QuickCheck.Utf8 (genValidUtf8)
 
 import           Tinfoil.Data
 import           Tinfoil.Random
@@ -32,7 +32,10 @@ excludedChars :: Gen [Char]
 excludedChars = arbitrary `suchThat` (/= (NE.toList credentialCharSet))
 
 instance Arbitrary Credential where
-  arbitrary = Credential <$> genValidUtf8
+  arbitrary = do
+    n <- credentialLength
+    bs <- fmap BS.pack . vectorOf n $ choose (0, 255)
+    pure $ Credential bs
 
 -- Fake entropy.
 instance Arbitrary Entropy where


### PR DESCRIPTION
Required for `eminence`.

Also bump IO test iterations to fit with the guidelines.

@markhibberd 

Fixes #17.