### PR TITLE
Fix up KDF type and add instance for scrypt

### DIFF
--- a/src/Tinfoil/Data/KDF.hs
+++ b/src/Tinfoil/Data/KDF.hs
@@ -36,8 +36,9 @@ newtype Credential =
 instance NFData Credential
 
 data Verified =
-    Verified
-  | NotVerified
+    Verified -- ^ Credential hash is well-formed and credential is correct.
+  | NotVerified -- ^ Credential hash is well-formed but credential is not correct.
+  | VerificationError -- ^ Credential hash is not well-formed.
   deriving (Eq, Show, Generic)
 
 instance NFData Verified
@@ -64,7 +65,7 @@ data Verification = Verification !Verified !NeedsRehash
 --  processors (GPUs, mining ASICs, et cetera).
 data KDF = KDF
   { genHash        :: (Credential -> IO CredentialHash)
-  , hashCredential :: (CredentialHash -> Credential -> IO (Maybe Verified))
-  , verifyNoHash   :: (Credential -> IO (Maybe Verified))
+  , hashCredential :: (CredentialHash -> Credential -> IO Verified)
+  , verifyNoHash   :: (Credential -> IO Verified)
   , mcfPrefix      :: Text
   }

--- a/src/Tinfoil/Data/KDF.hs
+++ b/src/Tinfoil/Data/KDF.hs
@@ -64,7 +64,7 @@ data Verification = Verification !Verified !NeedsRehash
 --  processors (GPUs, mining ASICs, et cetera).
 data KDF = KDF
   { genHash        :: (Credential -> IO CredentialHash)
-  , hashCredential :: (Credential -> CredentialHash -> IO Verified)
-  , verifyNoHash   :: IO Verified
+  , hashCredential :: (CredentialHash -> Credential -> IO (Maybe Verified))
+  , verifyNoHash   :: (Credential -> IO (Maybe Verified))
   , mcfPrefix      :: Text
   }

--- a/src/Tinfoil/KDF.hs
+++ b/src/Tinfoil/KDF.hs
@@ -1,41 +1,16 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Tinfoil.KDF(
-    safeEq
-  , hashEq
+    defaultScrypt
 ) where
 
-import           Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-
-import           P
-
-import           System.IO (IO)
-
 import           Tinfoil.Data
+import qualified Tinfoil.KDF.Scrypt as Scrypt
 
--- | Constant-time comparison. Not at all optimised, and accordingly
--- around three orders of magnitude slower than the 'Eq' instance
--- (which is on the order of a microsecond for password-hash-sized
--- 'ByteString's).
-safeEq :: ByteString -> ByteString -> IO Bool
-safeEq a b = pure $
-  (&&) (la == lb) $! (match (buffered a) (buffered b) True)
-  where
-    buffered bs = bs <> BS.replicate (maxLen - (BS.length bs)) 0
-
-    maxLen = fromIntegral $ max la lb
-
-    (la, lb) = (BS.length a, BS.length b)
-
-    match as bs acc
-      | BS.null as || BS.null bs =
-          acc
-      | otherwise                =
-          match (BS.tail as) (BS.tail bs)
-              ((&&) acc $! (BS.head as == BS.head bs))
-
--- | This is in IO because hash comparison is not a pure function -
--- the timing is one of the outputs.
-hashEq :: CredentialHash -> CredentialHash -> IO Bool
-hashEq (CredentialHash a) (CredentialHash b) = safeEq a b
+defaultScrypt :: KDF
+defaultScrypt =
+  KDF
+    (Scrypt.hashCredential Scrypt.defaultParams)
+    Scrypt.verifyCredential
+    (Scrypt.verifyNoCredential Scrypt.defaultParams)
+    Scrypt.scryptMCFPrefix

--- a/src/Tinfoil/KDF/Common.hs
+++ b/src/Tinfoil/KDF/Common.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Tinfoil.KDF.Common(
+    safeEq
+  , hashEq
+) where
+
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+
+import           P
+
+import           System.IO (IO)
+
+import           Tinfoil.Data
+
+-- | Constant-time comparison. Not at all optimised, and accordingly
+-- around three orders of magnitude slower than the 'Eq' instance
+-- (which is on the order of a microsecond for password-hash-sized
+-- 'ByteString's).
+safeEq :: ByteString -> ByteString -> IO Bool
+safeEq a b = pure $
+  (&&) (la == lb) $! (match (buffered a) (buffered b) True)
+  where
+    buffered bs = bs <> BS.replicate (maxLen - (BS.length bs)) 0
+
+    maxLen = fromIntegral $ max la lb
+
+    (la, lb) = (BS.length a, BS.length b)
+
+    match as bs acc
+      | BS.null as || BS.null bs =
+          acc
+      | otherwise                =
+          match (BS.tail as) (BS.tail bs)
+              ((&&) acc $! (BS.head as == BS.head bs))
+
+-- | This is in IO because hash comparison is not a pure function -
+-- the timing is one of the outputs.
+hashEq :: CredentialHash -> CredentialHash -> IO Bool
+hashEq (CredentialHash a) (CredentialHash b) = safeEq a b

--- a/src/Tinfoil/KDF/Scrypt.hs
+++ b/src/Tinfoil/KDF/Scrypt.hs
@@ -31,23 +31,23 @@ defaultParams = scryptParams 16 8 12 -- N = 2^16, r = 8, p = 12
 salt :: IO Entropy
 salt = entropy 32
 
-verifyNoCredential :: ScryptParams -> Credential -> IO (Maybe Verified)
+verifyNoCredential :: ScryptParams -> Credential -> IO Verified
 verifyNoCredential p c = do
   e <- salt
   h <- scrypt p e c
   void $ h `safeEq` ""
-  pure $ Just NotVerified
+  pure NotVerified
 
-verifyCredential :: CredentialHash -> Credential -> IO (Maybe Verified)
+verifyCredential :: CredentialHash -> Credential -> IO Verified
 verifyCredential ch c = case separate ch of
   Just (p, e, h) -> do
     void salt -- timing consistency
     h' <- scrypt p e c
     r <- h' `safeEq` h
     if r
-      then pure $ Just Verified
-      else pure $ Just NotVerified
-  Nothing        -> pure Nothing
+      then pure Verified
+      else pure NotVerified
+  Nothing        -> pure VerificationError
 
 hashCredential :: ScryptParams -> Credential -> IO CredentialHash
 hashCredential params cred = do

--- a/src/Tinfoil/KDF/Scrypt.hs
+++ b/src/Tinfoil/KDF/Scrypt.hs
@@ -3,6 +3,7 @@
 module Tinfoil.KDF.Scrypt(
     defaultParams
   , hashCredential
+  , scryptMCFPrefix
   , verifyCredential
   , verifyNoCredential
 ) where
@@ -14,8 +15,11 @@ import           System.IO
 import           Tinfoil.Data (Credential(..), CredentialHash(..), Entropy(..))
 import           Tinfoil.Data (Verified(..))
 import           Tinfoil.KDF.Scrypt.Internal
-import           Tinfoil.KDF
+import           Tinfoil.KDF.Common
 import           Tinfoil.Random (entropy)
+
+scryptMCFPrefix :: Text
+scryptMCFPrefix = "$scrypt0"
 
 -- |
 -- Nontrivial but reasonable memory usage, and a runtime of at

--- a/test/Test/IO/Tinfoil/KDF/Common.hs
+++ b/test/Test/IO/Tinfoil/KDF/Common.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell   #-}
 
-module Test.IO.Tinfoil.KDF where
+module Test.IO.Tinfoil.KDF.Common where
 
 import           Data.ByteString (ByteString)
 
@@ -14,7 +14,7 @@ import           P
 
 import           System.IO
 
-import           Tinfoil.KDF
+import           Tinfoil.KDF.Common
 
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()

--- a/test/Test/IO/Tinfoil/KDF/Scrypt.hs
+++ b/test/Test/IO/Tinfoil/KDF/Scrypt.hs
@@ -30,20 +30,20 @@ prop_verifyCredential_valid p (UniquePair good bad) = testIO $ do
   ch <- hashCredential p good
   r1 <- verifyCredential ch good
   r2 <- verifyCredential ch bad
-  pure $ (r1, r2) === (Just Verified, Just NotVerified)
+  pure $ (r1, r2) === (Verified, NotVerified)
 
 prop_verifyCredential_timing :: UniquePair Credential -> Property
 prop_verifyCredential_timing (UniquePair good bad) = testIO $ do
   ch <- hashCredential defaultParams good
   (t1, r1) <- withCPUTime $ verifyCredential ch good
   (t2, r2) <- withCPUTime $ verifyCredential ch bad
-  pure $ (r1, r2, t1 >= minHashTime, t2 >= minHashTime) === (Just Verified, Just NotVerified, True, True)
+  pure $ (r1, r2, t1 >= minHashTime, t2 >= minHashTime) === (Verified, NotVerified, True, True)
 
 
 prop_verifyCredential_invalid :: Credential -> InvalidCredentialHash -> Property
 prop_verifyCredential_invalid c (InvalidCredentialHash ch) = testIO $ do
   r <- verifyCredential ch c
-  pure $ r === Nothing
+  pure $ r === VerificationError
 
 -- Run twice and check the times to make sure we're not memoizing the result.
 prop_verifyNoCredential :: Credential -> Property
@@ -51,7 +51,7 @@ prop_verifyNoCredential c = testIO $ do
   let a = verifyNoCredential defaultParams c
   (t1, r1) <- withCPUTime a
   (t2, r2) <- withCPUTime a
-  pure $ (r1, r2, t1 > minHashTime, t2 > minHashTime) === (Just NotVerified, Just NotVerified, True, True)
+  pure $ (r1, r2, t1 > minHashTime, t2 > minHashTime) === (NotVerified, NotVerified, True, True)
   
 
 prop_scrypt :: ScryptParams -> Credential -> Property

--- a/test/bench.hs
+++ b/test/bench.hs
@@ -20,7 +20,7 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
 
 import           Tinfoil.Random
-import           Tinfoil.KDF
+import           Tinfoil.KDF.Common
 import qualified Tinfoil.KDF.Scrypt as Scrypt
 
 bsTriple :: Int -> Int -> Gen (ByteString, ByteString, ByteString)

--- a/test/test-io.hs
+++ b/test/test-io.hs
@@ -1,13 +1,13 @@
 import           Disorder.Core.Main
 
 import qualified Test.IO.Tinfoil.Random
-import qualified Test.IO.Tinfoil.KDF
+import qualified Test.IO.Tinfoil.KDF.Common
 import qualified Test.IO.Tinfoil.KDF.Scrypt
 
 main :: IO ()
 main =
   disorderMain [
     Test.IO.Tinfoil.Random.tests
-  , Test.IO.Tinfoil.KDF.tests
+  , Test.IO.Tinfoil.KDF.Common.tests
   , Test.IO.Tinfoil.KDF.Scrypt.tests
   ]

--- a/tinfoil.cabal
+++ b/tinfoil.cabal
@@ -38,6 +38,7 @@ library
                        Tinfoil.Data.Random
                        Tinfoil.Data.Signing
                        Tinfoil.KDF
+                       Tinfoil.KDF.Common
                        Tinfoil.KDF.Scrypt
                        Tinfoil.KDF.Scrypt.Internal
                        Tinfoil.Random


### PR DESCRIPTION
@markhibberd 

This will allow me to get rid of the `KDF` type in `eminence` and consequently a lot of the cruft in `Eminence.Crypt`.