### PR TITLE
Add MCF awareness

### DIFF
--- a/src/Tinfoil.hs
+++ b/src/Tinfoil.hs
@@ -7,3 +7,4 @@ module Tinfoil(
 
 import           Tinfoil.Data as X
 import           Tinfoil.KDF as X
+import           Tinfoil.Random as X

--- a/src/Tinfoil/Data/KDF.hs
+++ b/src/Tinfoil/Data/KDF.hs
@@ -105,11 +105,11 @@ instance NFData MCFPrefix
 renderMCFPrefix :: MCFPrefix -> ByteString
 renderMCFPrefix Scrypt0 = "scrypt0"
 
-parseMCFPrefix :: ByteString -> Maybe MCFPrefix
+parseMCFPrefix :: ByteString -> Maybe' MCFPrefix
 parseMCFPrefix "scrypt0" = pure Scrypt0
-parseMCFPrefix _ = Nothing
+parseMCFPrefix _ = Nothing'
 
-unpackMCFHash :: MCFHash -> Maybe (MCFPrefix, CredentialHash)
+unpackMCFHash :: MCFHash -> Maybe' (MCFPrefix, CredentialHash)
 unpackMCFHash (MCFHash bs) = do
   (p, h) <- splitMCF
   p' <- parseMCFPrefix p
@@ -117,7 +117,7 @@ unpackMCFHash (MCFHash bs) = do
   where
     splitMCF = case BS.split mcfDelimiter bs of
       ("":x:ys) -> pure (x, BS.intercalate (BS.singleton mcfDelimiter) ys)
-      _ -> Nothing
+      _ -> Nothing'
 
 packMCFHash :: MCFPrefix -> CredentialHash -> MCFHash
 packMCFHash p h = MCFHash $ BS.concat [

--- a/src/Tinfoil/Data/KDF.hs
+++ b/src/Tinfoil/Data/KDF.hs
@@ -92,6 +92,7 @@ data KDF = KDF
   , kdfVerifyCredential :: (CredentialHash -> Credential -> IO Verified)
   , kdfVerifyNoCredential :: (Credential -> IO Verified)
   , kdfMcfPrefix :: MCFPrefix
+  , kdfUpToDate :: CredentialHash -> Maybe' NeedsRehash
   }
 
 -- | Non-standardized modular crypt format string. Uniquely identifies (from

--- a/src/Tinfoil/KDF.hs
+++ b/src/Tinfoil/KDF.hs
@@ -34,7 +34,7 @@ hash mp c = do
 
 verify :: MCFHash -> Credential -> IO Verified
 verify mh c =
-  maybe (pure VerificationError) (uncurry verify') $ unpackMCFHash mh
+  maybe' (pure VerificationError) (uncurry verify') $ unpackMCFHash mh
   where
     verify' mcf ch =
       let kdf = kdfFor mcf in

--- a/src/Tinfoil/KDF.hs
+++ b/src/Tinfoil/KDF.hs
@@ -4,6 +4,7 @@ module Tinfoil.KDF(
     defaultScrypt
   , hash
   , kdfFor
+  , needsRehash
   , verify
   , verifyNoCredential
 ) where
@@ -22,6 +23,7 @@ defaultScrypt =
     Scrypt.verifyCredential
     (Scrypt.verifyNoCredential Scrypt.defaultParams)
     Scrypt0
+    (Scrypt.paramsUpToDate Scrypt.defaultParams)
 
 kdfFor :: MCFPrefix -> KDF
 kdfFor Scrypt0 = defaultScrypt
@@ -45,3 +47,8 @@ verifyNoCredential mp c =
   (kdfVerifyNoCredential kdf) $ c
   where
     kdf = kdfFor mp
+
+needsRehash :: MCFHash -> Maybe' NeedsRehash
+needsRehash mh = do
+  (p, h) <- unpackMCFHash mh
+  (kdfUpToDate (kdfFor p)) h

--- a/src/Tinfoil/KDF/Scrypt.hs
+++ b/src/Tinfoil/KDF/Scrypt.hs
@@ -5,7 +5,6 @@ module Tinfoil.KDF.Scrypt(
   , defaultParams
   , hashCredential
   , paramsUpToDate
-  , scryptMCFPrefix
   , verifyCredential
   , verifyNoCredential
 ) where
@@ -21,9 +20,6 @@ import           Tinfoil.Data (Verified(..), NeedsRehash(..))
 import           Tinfoil.KDF.Scrypt.Internal
 import           Tinfoil.KDF.Common
 import           Tinfoil.Random (entropy)
-
-scryptMCFPrefix :: Text
-scryptMCFPrefix = "$scrypt0$"
 
 -- |
 -- Nontrivial but reasonable memory usage, and a runtime of at

--- a/test/Test/IO/Tinfoil/KDF.hs
+++ b/test/Test/IO/Tinfoil/KDF.hs
@@ -15,7 +15,7 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
 import           Test.Tinfoil.Arbitrary
 
-import           Tinfoil.Data (Credential(..), Verified(..), MCFPrefix(..))
+import           Tinfoil.Data
 import           Tinfoil.KDF
 
 -- 1.5 seconds in picoseconds
@@ -50,6 +50,11 @@ prop_verifyNoCredential mp c = testIO $ do
   (t1, r1) <- withCPUTime a
   (t2, r2) <- withCPUTime a
   pure $ (r1, r2, t1 > minHashTime, t2 > minHashTime) === (NotVerified, NotVerified, True, True)
+
+prop_needsRehash :: MCFPrefix -> Credential -> Property
+prop_needsRehash mp c = testIO $ do
+  h <- hash mp c
+  pure $ (needsRehash h) === (Just' UpToDate)
 
 return []
 tests :: IO Bool

--- a/test/Test/IO/Tinfoil/KDF.hs
+++ b/test/Test/IO/Tinfoil/KDF.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Test.IO.Tinfoil.KDF where
+
+import           Disorder.Core.IO (testIO, withCPUTime)
+import           Disorder.Core.UniquePair (UniquePair(..))
+
+import           P
+
+import           System.IO
+
+import           Test.QuickCheck
+import           Test.QuickCheck.Instances ()
+import           Test.Tinfoil.Arbitrary
+
+import           Tinfoil.Data (Credential(..), Verified(..), MCFPrefix(..))
+import           Tinfoil.KDF
+
+-- 1.5 seconds in picoseconds
+minHashTime :: Integer
+minHashTime = 15 * 10^(11 :: Integer)
+
+prop_verify_valid :: MCFPrefix -> UniquePair Credential -> Property
+prop_verify_valid mp (UniquePair good bad) = testIO $ do
+  ch <- hash mp good
+  r1 <- verify ch good
+  r2 <- verify ch bad
+  pure $ (r1, r2) === (Verified, NotVerified)
+
+prop_verify_timing :: MCFPrefix -> UniquePair Credential -> Property
+prop_verify_timing mp (UniquePair good bad) = testIO $ do
+  ch <- hash mp good
+  (t1, r1) <- withCPUTime $ verify ch good
+  (t2, r2) <- withCPUTime $ verify ch bad
+  pure $ (r1, r2, t1 >= minHashTime, t2 >= minHashTime) === (Verified, NotVerified, True, True)
+
+prop_verify_invalid :: Credential -> Property
+prop_verify_invalid c =
+  forAll ((,) <$> genWellFormedMCFHash <*> genInvalidMCFHash) $ \(wfh, ih) -> testIO $ do
+    r1 <- verify wfh c
+    r2 <- verify ih c
+    pure $ (r1, r2) === (VerificationError, VerificationError)
+
+-- Run twice and check the times to make sure we're not memoizing the result.
+prop_verifyNoCredential :: MCFPrefix -> Credential -> Property
+prop_verifyNoCredential mp c = testIO $ do
+  let a = verifyNoCredential mp c
+  (t1, r1) <- withCPUTime a
+  (t2, r2) <- withCPUTime a
+  pure $ (r1, r2, t1 > minHashTime, t2 > minHashTime) === (NotVerified, NotVerified, True, True)
+
+return []
+tests :: IO Bool
+tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 10 } )

--- a/test/Test/IO/Tinfoil/KDF/Scrypt.hs
+++ b/test/Test/IO/Tinfoil/KDF/Scrypt.hs
@@ -41,10 +41,11 @@ prop_verifyCredential_timing (UniquePair good bad) = testIO $ do
   pure $ (r1, r2, t1 >= minHashTime, t2 >= minHashTime) === (Verified, NotVerified, True, True)
 
 
-prop_verifyCredential_invalid :: Credential -> InvalidCredentialHash -> Property
-prop_verifyCredential_invalid c (InvalidCredentialHash ch) = testIO $ do
-  r <- verifyCredential ch c
-  pure $ r === VerificationError
+prop_verifyCredential_invalid :: Credential -> Property
+prop_verifyCredential_invalid c =
+  forAll genInvalidCredentialHash $ \ch -> testIO $ do
+    r <- verifyCredential ch c
+    pure $ r === VerificationError
 
 -- Run twice and check the times to make sure we're not memoizing the result.
 prop_verifyNoCredential :: Credential -> Property

--- a/test/Test/Tinfoil/Arbitrary.hs
+++ b/test/Test/Tinfoil/Arbitrary.hs
@@ -41,14 +41,9 @@ instance Arbitrary Credential where
 instance Arbitrary Entropy where
   arbitrary = Entropy <$> arbitrary
 
-newtype InvalidCredentialHash =
-  InvalidCredentialHash {
-    unInvalidCredentialHash :: CredentialHash
-  } deriving (Eq, Show)
-
-instance Arbitrary InvalidCredentialHash where
-  arbitrary = InvalidCredentialHash <$> 
-    ((CredentialHash . T.encodeUtf8) <$> elements muppets)
+genInvalidCredentialHash :: Gen CredentialHash
+genInvalidCredentialHash =
+  ((CredentialHash . T.encodeUtf8) <$> elements muppets)
 
 newtype DrawBits =
   DrawBits {
@@ -88,9 +83,15 @@ instance Arbitrary ScryptParams where
 instance Eq CredentialHash where
   (CredentialHash a) == (CredentialHash b) = a == b
 
+-- Unsafe, test code only.
+instance Eq MCFHash where
+  (MCFHash a) == (MCFHash b) = a == b
+
 instance Arbitrary KeyedHashFunction where
   arbitrary = elements [minBound..maxBound]
 
 instance Arbitrary SignatureVersion where
   arbitrary = elements [minBound..maxBound]
 
+instance Arbitrary MCFPrefix where
+  arbitrary = elements [minBound..maxBound]

--- a/test/Test/Tinfoil/Data/KDF.hs
+++ b/test/Test/Tinfoil/Data/KDF.hs
@@ -23,7 +23,7 @@ prop_tripping_MCFHash :: Property
 prop_tripping_MCFHash = forAll ((,) <$> arbitrary <*> genInvalidCredentialHash) $ \mcfPair ->
   let mcfh = uncurry packMCFHash mcfPair
       mcfPair' = unpackMCFHash mcfh in
-  mcfPair' === Just mcfPair
+  mcfPair' === Just' mcfPair
 
 return []
 tests :: IO Bool

--- a/test/Test/Tinfoil/Data/KDF.hs
+++ b/test/Test/Tinfoil/Data/KDF.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Test.Tinfoil.Data.KDF where
+
+import           Disorder.Core.Tripping (tripping)
+
+import           P
+
+import           System.IO
+
+import           Tinfoil.Data.KDF
+
+import           Test.Tinfoil.Arbitrary
+import           Test.QuickCheck
+
+prop_tripping_MCFPrefix :: MCFPrefix -> Property
+prop_tripping_MCFPrefix = tripping renderMCFPrefix parseMCFPrefix
+
+prop_tripping_MCFHash :: Property
+prop_tripping_MCFHash = forAll ((,) <$> arbitrary <*> genInvalidCredentialHash) $ \mcfPair ->
+  let mcfh = uncurry packMCFHash mcfPair
+      mcfPair' = unpackMCFHash mcfh in
+  mcfPair' === Just mcfPair
+
+return []
+tests :: IO Bool
+tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 100 } )

--- a/test/Test/Tinfoil/KDF/Scrypt.hs
+++ b/test/Test/Tinfoil/KDF/Scrypt.hs
@@ -30,8 +30,8 @@ prop_combine_separate = tripping (uncurry3 combine) separate
     uncurry3 :: (a -> b -> c -> d) -> ((a, b, c) -> d)
     uncurry3 f = \(x, y, z) -> f x y z
 
-prop_paramsUpToDate_bad :: InvalidCredentialHash -> Property
-prop_paramsUpToDate_bad (InvalidCredentialHash h) =
+prop_paramsUpToDate_bad :: Property
+prop_paramsUpToDate_bad = forAll genInvalidCredentialHash $ \h ->
   let r = paramsUpToDate defaultParams h in
   r === Nothing'
 

--- a/test/Test/Tinfoil/KDF/Scrypt.hs
+++ b/test/Test/Tinfoil/KDF/Scrypt.hs
@@ -17,7 +17,6 @@ import           Tinfoil.Data (Entropy(..))
 import           Tinfoil.KDF.Scrypt
 import           Tinfoil.KDF.Scrypt.Internal
 
-
 import           Test.Tinfoil.Arbitrary
 import           Test.QuickCheck
 

--- a/test/test-io.hs
+++ b/test/test-io.hs
@@ -1,6 +1,7 @@
 import           Disorder.Core.Main
 
 import qualified Test.IO.Tinfoil.Random
+import qualified Test.IO.Tinfoil.KDF
 import qualified Test.IO.Tinfoil.KDF.Common
 import qualified Test.IO.Tinfoil.KDF.Scrypt
 import qualified Test.IO.Tinfoil.KDF.Scrypt.Compat
@@ -9,6 +10,7 @@ main :: IO ()
 main =
   disorderMain [
     Test.IO.Tinfoil.Random.tests
+  , Test.IO.Tinfoil.KDF.tests
   , Test.IO.Tinfoil.KDF.Common.tests
   , Test.IO.Tinfoil.KDF.Scrypt.tests
   , Test.IO.Tinfoil.KDF.Scrypt.Compat.tests

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,5 +1,6 @@
 import           Disorder.Core.Main
 
+import qualified Test.Tinfoil.Data.KDF
 import qualified Test.Tinfoil.Data.Signing
 import qualified Test.Tinfoil.Random
 import qualified Test.Tinfoil.KDF.Scrypt
@@ -7,7 +8,8 @@ import qualified Test.Tinfoil.KDF.Scrypt
 main :: IO ()
 main =
   disorderMain [
-    Test.Tinfoil.Data.Signing.tests
+    Test.Tinfoil.Data.KDF.tests
+  , Test.Tinfoil.Data.Signing.tests
   , Test.Tinfoil.Random.tests
   , Test.Tinfoil.KDF.Scrypt.tests
   ]


### PR DESCRIPTION
This should allow all MCF-related functionality to be removed from clients. The new usage pattern will look like

```haskell
import Tinfoil (MCFPrefix(..), hash, verify, verifyNoCredential, renderMCFHash)

myKDF :: MCFPrefix
myKDF = Scrypt0
-- [...]
h <- hash myKDF credential
dbInsert $ renderMCFHash h
-- [...]
v <- verify storedHash userCredential
-- [...]
v' <- verifyNoCredential myKDF userCredential
```

Users will no longer deal with `CredentialHashes`, just `MCFHash`es which are opaque (not quite opaque because they need to be converted to/from `ByteString`s, but there's no need for the user to modify them). An MCF hash generated by `Tinfoil.hash` should always be able to be verified by `Tinfoil.verify`.

A client should be able to switch KDF algorithms just by changing the MCF prefix they pass; checking for updates will be in the next PR.

@markhibberd 

Fixes #26.