### PR TITLE
Expose SHA256

### DIFF
--- a/src/Tinfoil/Data.hs
+++ b/src/Tinfoil/Data.hs
@@ -3,6 +3,7 @@ module Tinfoil.Data(
     module X
 ) where
 
+import           Tinfoil.Data.Hash as X
 import           Tinfoil.Data.KDF as X
 import           Tinfoil.Data.Random as X
 import           Tinfoil.Data.Signing as X

--- a/src/Tinfoil/Data/Hash.hs
+++ b/src/Tinfoil/Data/Hash.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
+module Tinfoil.Data.Hash(
+    Hash(..)
+  , hexDigest
+) where
+
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.Text.Encoding as T
+
+import           GHC.Generics (Generic)
+
+import           P
+
+-- | Binary representation of a hash.
+newtype Hash =
+  Hash {
+    unHash :: ByteString
+  } deriving (Eq, Show, Generic)
+
+instance NFData Hash
+
+hexDigest :: Hash -> Text
+hexDigest = T.decodeUtf8 . Base16.encode . unHash

--- a/src/Tinfoil/Hash.hs
+++ b/src/Tinfoil/Hash.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Tinfoil.Hash(
+    hashSHA256
+) where
+
+import           Crypto.Hash.Algorithms (SHA256)
+import qualified Crypto.Hash as Cryptonite
+
+import qualified Data.ByteArray as BA
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+
+import           P
+
+import           Tinfoil.Data.Hash
+
+hashSHA256 :: ByteString -> Hash
+hashSHA256 bs =
+  let dgst = Cryptonite.hash bs :: Cryptonite.Digest SHA256 in
+  Hash . BS.pack $ BA.unpack dgst

--- a/test/Test/Tinfoil/Hash.hs
+++ b/test/Test/Tinfoil/Hash.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Test.Tinfoil.Hash where
+
+import           Data.ByteString (ByteString)
+
+import           Disorder.Core.UniquePair (UniquePair(..))
+
+import           P
+
+import           System.IO
+
+import           Tinfoil.Hash
+
+import           Test.QuickCheck
+import           Test.QuickCheck.Instances ()
+
+prop_hashSHA256 :: UniquePair ByteString -> Property
+prop_hashSHA256 (UniquePair bs1 bs2) =
+  let h1 = hashSHA256 bs1
+      h2 = hashSHA256 bs2 in
+  (h1 == h2) === False
+
+return []
+tests :: IO Bool
+tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 1000 } )

--- a/test/Test/Tinfoil/Hash/TestVectors.hs
+++ b/test/Test/Tinfoil/Hash/TestVectors.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+
+module Test.Tinfoil.Hash.TestVectors where
+
+import           Data.ByteString (ByteString)
+
+import           P
+
+import           System.IO
+
+import           Tinfoil.Data.Hash
+import           Tinfoil.Hash
+
+import           Test.QuickCheck
+
+testTestVector :: (ByteString -> Hash) -> ByteString -> Text -> Property
+testTestVector f inVec outVec =
+  let r = hexDigest $ f inVec in
+  once $ r === outVec
+
+-- SHA2 test vectors from the
+-- <https://www.cosic.esat.kuleuven.be/nessie/testvectors/ NESSIE project>.
+
+prop_sha256TestVec1 =
+  testTestVector
+    hashSHA256
+    ""
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+prop_sha256TestVec2 =
+  testTestVector
+    hashSHA256
+    "a"
+    "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"
+
+prop_sha256TestVec3 =
+  testTestVector
+    hashSHA256
+    "abc"
+    "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+
+prop_sha256TestVec4 =
+  testTestVector
+    hashSHA256
+    "message digest"
+    "f7846f55cf23e14eebeab5b4e1550cad5b509e3348fbc4efa3a1413d393cb650"
+
+prop_sha256TestVec5 =
+  testTestVector
+    hashSHA256
+    "abcdefghijklmnopqrstuvwxyz"
+    "71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73"
+
+prop_sha256TestVec6 =
+  testTestVector
+    hashSHA256
+    "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+    "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"
+
+prop_sha256TestVec7 =
+  testTestVector
+    hashSHA256
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+    "db4bfcbd4da0cd85a60c3c37d3fbd8805c77f15fc6b1fdfe614ee0a7c8fdb4c0"
+
+prop_sha256TestVec8 =
+  testTestVector
+    hashSHA256
+    "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
+    "f371bc4a311f2b009eef952dd83ca80e2b60026c8e935592d0f9c308453c813e"
+
+return []
+tests :: IO Bool
+tests = $quickCheckAll

--- a/test/Test/Tinfoil/KDF/Scrypt.hs
+++ b/test/Test/Tinfoil/KDF/Scrypt.hs
@@ -36,4 +36,4 @@ prop_paramsUpToDate_bad = forAll genInvalidCredentialHash $ \h ->
 
 return []
 tests :: IO Bool
-tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 100 } )
+tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 1000 } )

--- a/test/test.hs
+++ b/test/test.hs
@@ -3,6 +3,7 @@ import           Disorder.Core.Main
 import qualified Test.Tinfoil.Data.KDF
 import qualified Test.Tinfoil.Data.Signing
 import qualified Test.Tinfoil.Hash
+import qualified Test.Tinfoil.Hash.TestVectors
 import qualified Test.Tinfoil.Random
 import qualified Test.Tinfoil.KDF.Scrypt
 
@@ -12,6 +13,7 @@ main =
     Test.Tinfoil.Data.KDF.tests
   , Test.Tinfoil.Data.Signing.tests
   , Test.Tinfoil.Hash.tests
+  , Test.Tinfoil.Hash.TestVectors.tests
   , Test.Tinfoil.Random.tests
   , Test.Tinfoil.KDF.Scrypt.tests
   ]

--- a/test/test.hs
+++ b/test/test.hs
@@ -2,6 +2,7 @@ import           Disorder.Core.Main
 
 import qualified Test.Tinfoil.Data.KDF
 import qualified Test.Tinfoil.Data.Signing
+import qualified Test.Tinfoil.Hash
 import qualified Test.Tinfoil.Random
 import qualified Test.Tinfoil.KDF.Scrypt
 
@@ -10,6 +11,7 @@ main =
   disorderMain [
     Test.Tinfoil.Data.KDF.tests
   , Test.Tinfoil.Data.Signing.tests
+  , Test.Tinfoil.Hash.tests
   , Test.Tinfoil.Random.tests
   , Test.Tinfoil.KDF.Scrypt.tests
   ]

--- a/tinfoil.cabal
+++ b/tinfoil.cabal
@@ -16,10 +16,13 @@ library
   build-depends:
                        base                            >= 3          && < 5
                      , ambiata-p
+                     , base16-bytestring               == 0.1.1.*
                      , base64-bytestring               == 1.0.0.*
                      , bytestring                      >= 0.10.4     && < 0.10.7
+                     , cryptonite                      == 0.15
                      , either                          >= 4.3        && < 4.5
                      , entropy                         == 0.3.7
+                     , memory                          == 0.11
                      , semigroups                      == 0.16.*
                      , text                            == 1.2.*
                      , transformers                    >= 0.3        && < 0.5
@@ -34,6 +37,7 @@ library
                        Paths_ambiata_tinfoil
                        Tinfoil
                        Tinfoil.Data
+                       Tinfoil.Data.Hash
                        Tinfoil.Data.KDF
                        Tinfoil.Data.Random
                        Tinfoil.Data.Signing
@@ -41,6 +45,7 @@ library
                        Tinfoil.KDF.Common
                        Tinfoil.KDF.Scrypt
                        Tinfoil.KDF.Scrypt.Internal
+                       Tinfoil.Hash
                        Tinfoil.Random
                        Tinfoil.Random.Internal
 


### PR DESCRIPTION
Exposing an implementation of SHA256 for use in request signing.

Have had a look at the implementation in `cryptonite`; it's bespoke (by the `cryptonite` author), but looks reasonable code-wise to me and the test vectors are all good.

Two of the C imports (`cryptonite_sha256_init` and `cryptonite_sha256_finalize`) are `unsafe`, so could potentially lock up a capability, but neither of them are able to block or run in non-constant time.

I'm not putting this in IO for now, with the reasoning that most applications of non-KDF cryptographic hashes aren't vulnerable to the kind of timing vulnerability exacerbated by lazy evaluation - assuming enumerating key IDs is infeasible for the request-signing case.

@markhibberd 