### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ belongs in `tinfoil`. This includes:
  - Credential hashing and verification.
  - Key derivation functions.
  - Key and credential generation.
+ - Nonce generation.
  - HMACs and signed requests.
  - Bindings and wrappers around low-level libraries (`scrypt`,
    `libsodium`, et cetera).

--- a/src/Tinfoil/Comparison.hs
+++ b/src/Tinfoil/Comparison.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 module Tinfoil.Comparison(
-    safeEq
+    ConstEq(..)
+  , safeEq
   ) where
 
 import           Data.ByteString (ByteString)
@@ -14,6 +15,25 @@ import           Foreign.C
 import           P
 
 import           System.IO (IO)
+
+-- | Constant-time equality class; '==#' compares values in 'IO'
+-- for situations where comparison timing is a side-effect. The other
+-- method 'renderConstEq' converts the value to a 'ByteString'; the
+-- timing of '==#' is independent of whether its operands share a
+-- substring prefix.
+--
+-- In all cases where an 'Eq' instance is present, @x ==# y <=> x == y@.
+--
+-- Laws:
+--
+-- * @a ==# a@
+-- * @a ==# b && b ==# c ==> a ==# c@
+class ConstEq a where
+  renderConstEq :: a -> ByteString
+
+  (==#) :: a -> a -> IO Bool
+  x ==# y = safeEq (renderConstEq x) (renderConstEq y)
+infix 4 ==#
 
 -- | Constant-time comparison. Will reveal if the length of the inputs differ
 -- by exiting early, but will provide no other information.

--- a/src/Tinfoil/Data/MAC.hs
+++ b/src/Tinfoil/Data/MAC.hs
@@ -2,11 +2,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric #-}
 module Tinfoil.Data.MAC(
-    MAC(..)
-  , KeyedHashFunction(..)
+    KeyedHashFunction(..)
+  , MAC(..)
   , keyHashFunction
   , parseKeyedHashFunction
   , renderKeyedHashFunction
+  , renderMAC
   ) where
 
 import           Control.DeepSeq.Generics (genericRnf)
@@ -18,6 +19,7 @@ import           GHC.Generics (Generic)
 import           P
 
 import           Tinfoil.Data.Hash
+import           Tinfoil.Encode
 
 -- | Output of a message authentication code algorithm.
 -- Do not implement an 'Eq' instance for this type.
@@ -27,6 +29,10 @@ newtype MAC =
   } deriving (Show, Generic)
 
 instance NFData MAC where rnf = genericRnf
+
+-- | Hexadecimal encoding of a MAC.
+renderMAC :: MAC -> Text
+renderMAC = hexEncode . unMAC
 
 -- | Keyed-hash algorithm designator, for inclusion as a request
 -- parameter.

--- a/src/Tinfoil/Data/MAC.hs
+++ b/src/Tinfoil/Data/MAC.hs
@@ -18,6 +18,7 @@ import           GHC.Generics (Generic)
 
 import           P
 
+import           Tinfoil.Comparison
 import           Tinfoil.Data.Hash
 import           Tinfoil.Encode
 
@@ -29,6 +30,9 @@ newtype MAC =
   } deriving (Show, Generic)
 
 instance NFData MAC where rnf = genericRnf
+
+instance ConstEq MAC where
+  renderConstEq = unMAC
 
 -- | Hexadecimal encoding of a MAC.
 renderMAC :: MAC -> Text

--- a/test/Test/IO/Tinfoil/Comparison/Laws.hs
+++ b/test/Test/IO/Tinfoil/Comparison/Laws.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Test.IO.Tinfoil.Comparison.Laws where
+
+import           Disorder.Core.IO (testIO)
+
+import           P
+
+import           Test.QuickCheck
+
+import           Tinfoil.Comparison
+
+constEqId :: (ConstEq a) => a -> Property
+constEqId x = testIO $ do
+  r1 <- x ==# x
+  pure $ r1 === True

--- a/test/Test/IO/Tinfoil/Comparison/Laws.hs
+++ b/test/Test/IO/Tinfoil/Comparison/Laws.hs
@@ -13,3 +13,16 @@ constEqId :: (ConstEq a) => a -> Property
 constEqId x = testIO $ do
   r1 <- x ==# x
   pure $ r1 === True
+
+constEqTrans :: (ConstEq a) => a -> a -> a -> Property
+constEqTrans x y z = testIO $ do
+  xy <- x ==# y
+  yz <- y ==# z
+  xz <- x ==# z
+  pure $ (xy && yz) ==> (xz === True)
+
+constEqEq :: (Eq a, ConstEq a) => a -> a -> Property
+constEqEq x y = testIO $ do
+  r1 <- x ==# y
+  let r2 = x == y
+  pure $ r1 === r2

--- a/test/Test/IO/Tinfoil/Data/MAC.hs
+++ b/test/Test/IO/Tinfoil/Data/MAC.hs
@@ -4,6 +4,8 @@
 
 module Test.IO.Tinfoil.Data.MAC where
 
+import qualified Data.ByteString.Char8 as BSC
+
 import           P
 
 import           System.IO
@@ -14,8 +16,20 @@ import           Test.IO.Tinfoil.Comparison.Laws
 import           Test.Tinfoil.Arbitrary ()
 import           Test.QuickCheck
 
-prop_ConstEqId :: MAC -> Property
-prop_ConstEqId = constEqId
+prop_MAC_ConstEqId :: MAC -> Property
+prop_MAC_ConstEqId = constEqId
+
+prop_MAC_ConstEqEq :: MAC -> MAC -> Property
+prop_MAC_ConstEqEq = constEqEq
+
+-- | Can't use real random bytestrings here as the probability of three
+-- identical values is tiny.
+prop_MAC_ConstEqTrans :: Bool -> Bool -> Bool -> Property
+prop_MAC_ConstEqTrans x y z =
+  let x' = MAC . BSC.pack $ show x
+      y' = MAC . BSC.pack $ show y
+      z' = MAC . BSC.pack $ show z in
+  constEqTrans x' y' z'
 
 return []
 tests :: IO Bool

--- a/test/Test/IO/Tinfoil/Data/MAC.hs
+++ b/test/Test/IO/Tinfoil/Data/MAC.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.IO.Tinfoil.Data.MAC where
+
+import           P
+
+import           System.IO
+
+import           Tinfoil.Data.MAC
+
+import           Test.IO.Tinfoil.Comparison.Laws
+import           Test.Tinfoil.Arbitrary ()
+import           Test.QuickCheck
+
+prop_ConstEqId :: MAC -> Property
+prop_ConstEqId = constEqId
+
+return []
+tests :: IO Bool
+tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 100 } )

--- a/test/Test/Tinfoil/Arbitrary.hs
+++ b/test/Test/Tinfoil/Arbitrary.hs
@@ -87,3 +87,6 @@ instance Arbitrary SignatureAlgorithm where
 
 instance Arbitrary HashFunction where
   arbitrary = elements [minBound..maxBound]
+
+instance Arbitrary MAC where
+  arbitrary = genUBytes MAC 32

--- a/test/Test/Tinfoil/Gen.hs
+++ b/test/Test/Tinfoil/Gen.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Test.Tinfoil.Gen where
 
+import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
@@ -72,3 +73,9 @@ genOpenSSLSymmetricKey = do
   n <- choose (1, 100)
   xs <- vectorOf n $ choose (0, 255)
   pure . SymmetricKey $ BS.pack xs
+
+-- Generate bytes uniformly.
+genUBytes :: (ByteString -> a) -> Int -> Gen a
+genUBytes f n =
+  fmap (f . BS.pack) . vectorOf n $ choose (0, 255)
+

--- a/test/test-io.hs
+++ b/test/test-io.hs
@@ -1,6 +1,7 @@
 import           Disorder.Core.Main
 
 import qualified Test.IO.Tinfoil.Comparison
+import qualified Test.IO.Tinfoil.Data.MAC
 import qualified Test.IO.Tinfoil.Hash
 import qualified Test.IO.Tinfoil.KDF
 import qualified Test.IO.Tinfoil.KDF.Scrypt
@@ -14,6 +15,7 @@ main :: IO ()
 main =
   disorderMain [
     Test.IO.Tinfoil.Comparison.tests
+  , Test.IO.Tinfoil.Data.MAC.tests
   , Test.IO.Tinfoil.Hash.tests
   , Test.IO.Tinfoil.KDF.tests
   , Test.IO.Tinfoil.KDF.Scrypt.tests


### PR DESCRIPTION
 - Add `ConstEq` typeclass in `IO` to make integrating credentials/MACs into bigger data types easier (ref https://github.com/ambiata/zodiac/pull/23) (#45).
 - Fix hardcoded pointer size I forgot to deal with last PR (#46).
 - Render hex encoding of MACs so we don't have to do it in client libraries.

@markhibberd 

/cc @erikd-ambiata @thumphries @charleso 