### PR TITLE
GHC 8.0

### DIFF
--- a/ambiata-tinfoil.cabal
+++ b/ambiata-tinfoil.cabal
@@ -100,7 +100,7 @@ test-suite test
                      , ambiata-disorder-corpus
                      , ambiata-p
                      , bytestring                      >= 0.10.4     && < 0.11
-                     , QuickCheck                      == 2.7.*
+                     , QuickCheck                      >= 2.7        && < 2.9
                      , quickcheck-instances            == 0.3.*
                      , quickcheck-text                 == 0.1.*
                      , semigroups
@@ -123,7 +123,7 @@ test-suite test-io
                      , ambiata-disorder-corpus
                      , ambiata-p
                      , bytestring                      >= 0.10.4     && < 0.11
-                     , QuickCheck                      == 2.7.*
+                     , QuickCheck                      >= 2.7 &&     < 2.9
                      , quickcheck-instances            == 0.3.*
                      , quickcheck-text                 == 0.1.*
                      , process                         >= 1.2        && < 1.5
@@ -146,7 +146,7 @@ test-suite test-random
                      , ambiata-tinfoil
                      , ambiata-p
                      , bytestring                      >= 0.10.4     && < 0.11
-                     , QuickCheck                      == 2.7.*
+                     , QuickCheck                      >= 2.7 &&     < 2.9
                      , quickcheck-instances            == 0.3.*
                      , semigroups
                      , statistics                      == 0.13.2.*
@@ -165,7 +165,7 @@ benchmark bench
 
   build-depends:
                        base                            >= 3          && < 5
-                     , QuickCheck                      == 2.7.*
+                     , QuickCheck                      >= 2.7 &&     < 2.9
                      , ambiata-disorder-core
                      , ambiata-disorder-corpus
                      , ambiata-p

--- a/bin/ci.cabal-test
+++ b/bin/ci.cabal-test
@@ -1,0 +1,8 @@
+#!/bin/sh -exu
+
+#
+# Build ambiata-tinfoil-test package.
+#
+
+cd test
+../mafia build

--- a/boris.toml
+++ b/boris.toml
@@ -5,6 +5,16 @@
 
 [build.dist-7-10]
 
+[build.dist-8-0]
+
+[build.dist-cabal-test]
+  command = [["./bin/ci.cabal-test"]]
+
 [build.branches-7-8]
 
 [build.branches-7-10]
+
+[build.branches-8-0]
+
+[build.branches-cabal-test]
+  command = [["./bin/ci.cabal-test"]]

--- a/mafia
+++ b/mafia
@@ -118,4 +118,4 @@ case "$MODE" in
 upgrade) shift; run_upgrade "$@" ;;
 *) exec_mafia "$@"
 esac
-# Version: b965afd3fdc08aa19376a94cf35aec496b4f098f
+# Version: 90cf62f24007515d61be573e8b350b1ad4d1608c

--- a/master.toml
+++ b/master.toml
@@ -26,3 +26,11 @@
   HADDOCK_S3 = "$AMBIATA_HADDOCK_BRANCHES"
   GHC_VERSION = "7.10.2"
   CABAL_VERSION = "1.22.4.0"
+
+[build.branches-8-0]
+  GHC_VERSION = "8.0.1"
+  CABAL_VERSION = "1.24.0.0"
+
+[build.dist-8-0]
+  GHC_VERSION = "8.0.1"
+  CABAL_VERSION = "1.24.0.0"

--- a/src/Tinfoil.hs
+++ b/src/Tinfoil.hs
@@ -2,10 +2,16 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Tinfoil(
-    module X
+  -- * ubiquitous types
+    Verified(..)
+  -- * safe comparison
+  , ConstEq(..)
+  , safeEq
+
+  -- * utilities
+  , hexEncode
   ) where
 
-import           Tinfoil.Data as X
-import           Tinfoil.Encode as X
-import           Tinfoil.KDF as X
-import           Tinfoil.Random as X
+import           Tinfoil.Comparison
+import           Tinfoil.Data.KDF
+import           Tinfoil.Encode

--- a/test/ambiata-tinfoil-test.cabal
+++ b/test/ambiata-tinfoil-test.cabal
@@ -11,7 +11,7 @@ library
                      , ambiata-disorder-corpus
                      , ambiata-p
                      , bytestring                      >= 0.10.4     && < 0.11
-                     , QuickCheck                      == 2.7.*
+                     , QuickCheck                      >= 2.7        && < 2.9
                      , quickcheck-instances            == 0.3.*
                      , quickcheck-text                 == 0.1.*
                      , semigroups

--- a/test/ambiata-tinfoil-test.cabal
+++ b/test/ambiata-tinfoil-test.cabal
@@ -1,0 +1,21 @@
+name:                  ambiata-tinfoil-test
+version:               0.0.1
+cabal-version:         >= 1.8
+build-type:            Simple
+
+library
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-tinfoil
+                     , ambiata-disorder-core
+                     , ambiata-disorder-corpus
+                     , ambiata-p
+                     , bytestring                      >= 0.10.4     && < 0.11
+                     , QuickCheck                      == 2.7.*
+                     , quickcheck-instances            == 0.3.*
+                     , quickcheck-text                 == 0.1.*
+                     , semigroups
+                     , text                            == 1.2.*
+
+  exposed-modules:
+                       Test.Tinfoil.Arbitrary


### PR DESCRIPTION
On top of #47 ([diff](https://github.com/ambiata/tinfoil/compare/topic/render...topic/interface)).

Plus

 - Add cabal file for test package so `tinfoil` client projects like `zodiac` can use the instances therein. Is there a standard way to build these things nowadays? Couldn't figure out what's building e.g., `snooze-test`.
 - Restrict exports from `Tinfoil` root module, need to put more thought into what gets exported by default (#43).

@markhibberd /cc @thumphries @erikd-ambiata @charleso 