### PR TITLE
Parsers for MACs and keys

### DIFF
--- a/ambiata-tinfoil.cabal
+++ b/ambiata-tinfoil.cabal
@@ -100,7 +100,7 @@ test-suite test
                      , ambiata-disorder-corpus
                      , ambiata-p
                      , bytestring                      >= 0.10.4     && < 0.11
-                     , QuickCheck                      == 2.7.*
+                     , QuickCheck                      >= 2.7        && < 2.9
                      , quickcheck-instances            == 0.3.*
                      , quickcheck-text                 == 0.1.*
                      , semigroups
@@ -123,7 +123,7 @@ test-suite test-io
                      , ambiata-disorder-corpus
                      , ambiata-p
                      , bytestring                      >= 0.10.4     && < 0.11
-                     , QuickCheck                      == 2.7.*
+                     , QuickCheck                      >= 2.7 &&     < 2.9
                      , quickcheck-instances            == 0.3.*
                      , quickcheck-text                 == 0.1.*
                      , process                         >= 1.2        && < 1.5
@@ -146,7 +146,7 @@ test-suite test-random
                      , ambiata-tinfoil
                      , ambiata-p
                      , bytestring                      >= 0.10.4     && < 0.11
-                     , QuickCheck                      == 2.7.*
+                     , QuickCheck                      >= 2.7 &&     < 2.9
                      , quickcheck-instances            == 0.3.*
                      , semigroups
                      , statistics                      == 0.13.2.*
@@ -165,7 +165,7 @@ benchmark bench
 
   build-depends:
                        base                            >= 3          && < 5
-                     , QuickCheck                      == 2.7.*
+                     , QuickCheck                      >= 2.7 &&     < 2.9
                      , ambiata-disorder-core
                      , ambiata-disorder-corpus
                      , ambiata-p

--- a/bin/ci.cabal-test
+++ b/bin/ci.cabal-test
@@ -1,0 +1,8 @@
+#!/bin/sh -exu
+
+#
+# Build ambiata-tinfoil-test package.
+#
+
+cd test
+../mafia build

--- a/boris.toml
+++ b/boris.toml
@@ -5,6 +5,16 @@
 
 [build.dist-7-10]
 
+[build.dist-8-0]
+
+[build.dist-cabal-test]
+  command = [["./bin/ci.cabal-test"]]
+
 [build.branches-7-8]
 
 [build.branches-7-10]
+
+[build.branches-8-0]
+
+[build.branches-cabal-test]
+  command = [["./bin/ci.cabal-test"]]

--- a/mafia
+++ b/mafia
@@ -118,4 +118,4 @@ case "$MODE" in
 upgrade) shift; run_upgrade "$@" ;;
 *) exec_mafia "$@"
 esac
-# Version: b965afd3fdc08aa19376a94cf35aec496b4f098f
+# Version: 90cf62f24007515d61be573e8b350b1ad4d1608c

--- a/master.toml
+++ b/master.toml
@@ -26,3 +26,11 @@
   HADDOCK_S3 = "$AMBIATA_HADDOCK_BRANCHES"
   GHC_VERSION = "7.10.2"
   CABAL_VERSION = "1.22.4.0"
+
+[build.branches-8-0]
+  GHC_VERSION = "8.0.1"
+  CABAL_VERSION = "1.24.0.0"
+
+[build.dist-8-0]
+  GHC_VERSION = "8.0.1"
+  CABAL_VERSION = "1.24.0.0"

--- a/src/Tinfoil.hs
+++ b/src/Tinfoil.hs
@@ -2,10 +2,16 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Tinfoil(
-    module X
+  -- * ubiquitous types
+    Verified(..)
+  -- * safe comparison
+  , ConstEq(..)
+  , safeEq
+
+  -- * utilities
+  , hexEncode
   ) where
 
-import           Tinfoil.Data as X
-import           Tinfoil.Encode as X
-import           Tinfoil.KDF as X
-import           Tinfoil.Random as X
+import           Tinfoil.Comparison
+import           Tinfoil.Data.KDF
+import           Tinfoil.Encode

--- a/src/Tinfoil/Data/Key.hs
+++ b/src/Tinfoil/Data/Key.hs
@@ -8,6 +8,9 @@ module Tinfoil.Data.Key(
   , PublicKey(..)
   , SecretKey(..)
   , SymmetricKey(..)
+  , parseSymmetricKey
+  , renderSymmetricKey
+  , symmetricKeyLength
   ) where
 
 import           Control.DeepSeq.Generics (genericRnf)
@@ -24,6 +27,15 @@ newtype SymmetricKey =
   } deriving (Eq, Generic)
 
 instance NFData SymmetricKey where rnf = genericRnf
+
+symmetricKeyLength :: Int
+symmetricKeyLength = 32
+
+renderSymmetricKey :: SymmetricKey -> Text
+renderSymmetricKey = hexEncode . unSymmetricKey
+
+parseSymmetricKey :: Text -> Maybe' SymmetricKey
+parseSymmetricKey t = SymmetricKey <$> hexDecode symmetricKeyLength t
 
 data Ed25519
 

--- a/src/Tinfoil/Data/Key.hs
+++ b/src/Tinfoil/Data/Key.hs
@@ -21,6 +21,11 @@ import           GHC.Generics (Generic)
 
 import           P
 
+import           Tinfoil.Encode
+
+-- | A cryptographically-random string of bits. A 'SymmetricKey' is 32
+-- bytes wide, which is for an intended 128-bit security level
+-- assuming the possibility of birthday attacks.
 newtype SymmetricKey =
   SymmetricKey {
     unSymmetricKey :: ByteString

--- a/src/Tinfoil/Data/MAC.hs
+++ b/src/Tinfoil/Data/MAC.hs
@@ -13,10 +13,7 @@ module Tinfoil.Data.MAC(
 
 import           Control.DeepSeq.Generics (genericRnf)
 
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Base16 as B16
 import           Data.ByteString (ByteString)
-import qualified Data.Text.Encoding as T
 
 import           GHC.Generics (Generic)
 
@@ -44,11 +41,7 @@ renderMAC = hexEncode . unMAC
 
 -- | Parse the hexadecimal encoding of a MAC.
 parseMAC :: Text -> Maybe' MAC
-parseMAC t = case B16.decode (T.encodeUtf8 t) of
-  (x, "") -> if BS.length x == 32
-               then Just' $ MAC x
-               else Nothing'
-  _ -> Nothing'
+parseMAC t = MAC <$> hexDecode 32 t
 
 -- | Keyed-hash algorithm designator, for inclusion as a request
 -- parameter.

--- a/src/Tinfoil/Data/MAC.hs
+++ b/src/Tinfoil/Data/MAC.hs
@@ -6,13 +6,17 @@ module Tinfoil.Data.MAC(
   , MAC(..)
   , keyHashFunction
   , parseKeyedHashFunction
+  , parseMAC
   , renderKeyedHashFunction
   , renderMAC
   ) where
 
 import           Control.DeepSeq.Generics (genericRnf)
 
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as B16
 import           Data.ByteString (ByteString)
+import qualified Data.Text.Encoding as T
 
 import           GHC.Generics (Generic)
 
@@ -37,6 +41,14 @@ instance ConstEq MAC where
 -- | Hexadecimal encoding of a MAC.
 renderMAC :: MAC -> Text
 renderMAC = hexEncode . unMAC
+
+-- | Parse the hexadecimal encoding of a MAC.
+parseMAC :: Text -> Maybe' MAC
+parseMAC t = case B16.decode (T.encodeUtf8 t) of
+  (x, "") -> if BS.length x == 32
+               then Just' $ MAC x
+               else Nothing'
+  _ -> Nothing'
 
 -- | Keyed-hash algorithm designator, for inclusion as a request
 -- parameter.

--- a/src/Tinfoil/Encode.hs
+++ b/src/Tinfoil/Encode.hs
@@ -2,9 +2,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Tinfoil.Encode(
     hexEncode
+  , hexDecode
 ) where
 
 import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.Text.Encoding as T
 
@@ -12,3 +14,12 @@ import           P
 
 hexEncode :: ByteString -> Text
 hexEncode = T.decodeUtf8 . Base16.encode
+
+-- | Parse a hex-encoded bytestring of a given length (number of bytes
+-- in the data, not its hexadecimal encoding).
+hexDecode :: Int -> Text -> Maybe' ByteString
+hexDecode len t = case Base16.decode (T.encodeUtf8 t) of
+  (x, "") -> if BS.length x == len
+               then Just' x
+               else Nothing'
+  _ -> Nothing'

--- a/src/Tinfoil/Key.hs
+++ b/src/Tinfoil/Key.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Tinfoil.Key(
-    genSymmetricKey256
+    genSymmetricKey
 ) where
 
 import           P

--- a/src/Tinfoil/Key.hs
+++ b/src/Tinfoil/Key.hs
@@ -13,6 +13,6 @@ import           Tinfoil.Data.Random
 import           Tinfoil.Random
 
 -- | Generate a 256-bit symmetric cryptographic key.
-genSymmetricKey256 :: IO SymmetricKey
-genSymmetricKey256 = fmap (SymmetricKey . unEntropy) $ entropy 32
+genSymmetricKey :: IO SymmetricKey
+genSymmetricKey = fmap (SymmetricKey . unEntropy) $ entropy symmetricKeyLength
 

--- a/test/Test/Tinfoil/Arbitrary.hs
+++ b/test/Test/Tinfoil/Arbitrary.hs
@@ -70,8 +70,7 @@ instance Arbitrary MCFPrefix where
 
 instance Arbitrary SymmetricKey where
   arbitrary = do
-    n <- choose (0, 100)
-    xs <- vectorOf n $ choose (0, 255)
+    xs <- vectorOf 32 $ choose (0, 255)
     pure . SymmetricKey $ BS.pack xs
 
 -- Unsafe, test code only.

--- a/test/Test/Tinfoil/Data/Key.hs
+++ b/test/Test/Tinfoil/Data/Key.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Test.Tinfoil.Data.Key where
+
+import           Disorder.Core.Tripping (tripping)
+
+import           P
+
+import           System.IO
+
+import           Tinfoil.Data.Key
+
+import           Test.QuickCheck
+import           Test.Tinfoil.Arbitrary ()
+
+prop_tripping_SymmetricKey :: SymmetricKey -> Property
+prop_tripping_SymmetricKey = tripping renderSymmetricKey parseSymmetricKey
+
+return []
+tests :: IO Bool
+tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 100 } )

--- a/test/Test/Tinfoil/Data/MAC.hs
+++ b/test/Test/Tinfoil/Data/MAC.hs
@@ -19,6 +19,9 @@ import           Test.QuickCheck
 prop_tripping_KeyedHashFunction :: KeyedHashFunction -> Property
 prop_tripping_KeyedHashFunction = tripping renderKeyedHashFunction parseKeyedHashFunction
 
+prop_tripping_MAC :: MAC -> Property
+prop_tripping_MAC = tripping renderMAC parseMAC
+
 return []
 tests :: IO Bool
 tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 100 } )

--- a/test/Test/Tinfoil/Encode.hs
+++ b/test/Test/Tinfoil/Encode.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Test.Tinfoil.Encode where
+
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+
+import           Disorder.Core.Tripping (tripping)
+
+import           P
+
+import           System.IO
+
+import           Tinfoil.Encode
+
+import           Test.QuickCheck
+import           Test.QuickCheck.Instances ()
+
+prop_tripping_hex :: ByteString -> Property
+prop_tripping_hex bs =
+  let bl = BS.length bs in
+  tripping hexEncode (hexDecode bl) bs
+
+return []
+tests :: IO Bool
+tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 100 } )

--- a/test/ambiata-tinfoil-test.cabal
+++ b/test/ambiata-tinfoil-test.cabal
@@ -19,3 +19,4 @@ library
 
   exposed-modules:
                        Test.Tinfoil.Arbitrary
+                       Test.Tinfoil.Gen

--- a/test/ambiata-tinfoil-test.cabal
+++ b/test/ambiata-tinfoil-test.cabal
@@ -11,7 +11,7 @@ library
                      , ambiata-disorder-corpus
                      , ambiata-p
                      , bytestring                      >= 0.10.4     && < 0.11
-                     , QuickCheck                      == 2.7.*
+                     , QuickCheck                      >= 2.7        && < 2.9
                      , quickcheck-instances            == 0.3.*
                      , quickcheck-text                 == 0.1.*
                      , semigroups

--- a/test/ambiata-tinfoil-test.cabal
+++ b/test/ambiata-tinfoil-test.cabal
@@ -1,0 +1,21 @@
+name:                  ambiata-tinfoil-test
+version:               0.0.1
+cabal-version:         >= 1.8
+build-type:            Simple
+
+library
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-tinfoil
+                     , ambiata-disorder-core
+                     , ambiata-disorder-corpus
+                     , ambiata-p
+                     , bytestring                      >= 0.10.4     && < 0.11
+                     , QuickCheck                      == 2.7.*
+                     , quickcheck-instances            == 0.3.*
+                     , quickcheck-text                 == 0.1.*
+                     , semigroups
+                     , text                            == 1.2.*
+
+  exposed-modules:
+                       Test.Tinfoil.Arbitrary

--- a/test/test.hs
+++ b/test/test.hs
@@ -4,6 +4,7 @@ import qualified Test.Tinfoil.Data.Hash
 import qualified Test.Tinfoil.Data.KDF
 import qualified Test.Tinfoil.Data.MAC
 import qualified Test.Tinfoil.Data.Signing
+import qualified Test.Tinfoil.Encode
 import qualified Test.Tinfoil.Hash
 import qualified Test.Tinfoil.Hash.TestVectors
 import qualified Test.Tinfoil.KDF.Scrypt
@@ -18,6 +19,7 @@ main =
   , Test.Tinfoil.Data.KDF.tests
   , Test.Tinfoil.Data.MAC.tests
   , Test.Tinfoil.Data.Signing.tests
+  , Test.Tinfoil.Encode.tests
   , Test.Tinfoil.Hash.tests
   , Test.Tinfoil.Hash.TestVectors.tests
   , Test.Tinfoil.MAC.tests

--- a/test/test.hs
+++ b/test/test.hs
@@ -2,6 +2,7 @@ import           Disorder.Core.Main
 
 import qualified Test.Tinfoil.Data.Hash
 import qualified Test.Tinfoil.Data.KDF
+import qualified Test.Tinfoil.Data.Key
 import qualified Test.Tinfoil.Data.MAC
 import qualified Test.Tinfoil.Data.Signing
 import qualified Test.Tinfoil.Encode
@@ -17,6 +18,7 @@ main =
   disorderMain [
     Test.Tinfoil.Data.Hash.tests
   , Test.Tinfoil.Data.KDF.tests
+  , Test.Tinfoil.Data.Key.tests
   , Test.Tinfoil.Data.MAC.tests
   , Test.Tinfoil.Data.Signing.tests
   , Test.Tinfoil.Encode.tests


### PR DESCRIPTION
On top of #48 ([diff](https://github.com/ambiata/tinfoil/compare/topic/interface...topic/more)).

For use in `zodiac` and `eminence`, which need to decode them and store them in databases and such.

Also specify the length of a `SymmetricKey` for `tinfoil` purposes as 256 bits, just because I don't see any benefit to allowing other key lengths; anyone see any problems with this?

@markhibberd 