### PR TITLE
Add SecureToken

### DIFF
--- a/ambiata-tinfoil.cabal
+++ b/ambiata-tinfoil.cabal
@@ -44,6 +44,7 @@ library
                        Tinfoil.Data.MAC
                        Tinfoil.Data.Random
                        Tinfoil.Data.Signing
+                       Tinfoil.Data.Token
                        Tinfoil.Encode
                        Tinfoil.Hash
                        Tinfoil.KDF
@@ -55,6 +56,7 @@ library
                        Tinfoil.Random.Internal
                        Tinfoil.Signing.Ed25519
                        Tinfoil.Signing.Ed25519.Internal
+                       Tinfoil.Token
 
   extra-libraries:     sodium
 

--- a/src/Tinfoil/Data/Token.hs
+++ b/src/Tinfoil/Data/Token.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
+module Tinfoil.Data.Token(
+    SecureToken (..)
+  , secureTokenLength
+  ) where
+
+import           Control.DeepSeq.Generics (genericRnf)
+
+import           GHC.Generics (Generic)
+
+import           P
+
+-- | Cryptographically secure identifier, for things like API keys or
+-- password reset tokens.  This is a 32 character base-16 string
+-- (encoding a 128 bit random token).
+newtype SecureToken =
+  SecureToken {
+      unSecureToken :: Text
+    } deriving (Eq, Show, Generic)
+
+instance NFData SecureToken where rnf = genericRnf
+
+secureTokenLength :: Int
+secureTokenLength =
+  16

--- a/src/Tinfoil/Key.hs
+++ b/src/Tinfoil/Key.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Tinfoil.Key(
     genSymmetricKey
-) where
+  ) where
 
 import           P
 
@@ -15,4 +15,3 @@ import           Tinfoil.Random
 -- | Generate a 256-bit symmetric cryptographic key.
 genSymmetricKey :: IO SymmetricKey
 genSymmetricKey = fmap (SymmetricKey . unEntropy) $ entropy symmetricKeyLength
-

--- a/src/Tinfoil/Token.hs
+++ b/src/Tinfoil/Token.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Tinfoil.Token (
+    secureTokenRaw
+  , secureToken
+  ) where
+
+import           Data.ByteString (ByteString)
+
+import           P
+
+import           System.IO (IO)
+
+import           Tinfoil.Data.Token
+import           Tinfoil.Data.Random (Entropy (..))
+import           Tinfoil.Encode (hexEncode)
+import           Tinfoil.Random (entropy)
+
+-- | Cryptographically secure identifier, for things like API keys or
+-- password reset tokens.  Provided as a raw 'ByteString'.
+secureTokenRaw :: IO ByteString
+secureTokenRaw =
+  unEntropy <$> entropy secureTokenLength
+
+-- | Cryptographically secure identifier, for things like API keys or
+-- password reset tokens.  This is a 32 character base-16 string
+-- (encoding a 128 bit random token).
+secureToken :: IO SecureToken
+secureToken =
+  SecureToken . hexEncode <$> secureTokenRaw


### PR DESCRIPTION
@markhibberd @olorin 

This code has come straight out of `debruijn`. Since that library has been created, it has been twisted from 'user-facing-keys/ids' to 'user-facing-keys/ids AND some cryptographic keys. `tinfoil` should be source of all cryptographic keys, this will clean-up `debruijn`, and put the cryptographic bits into the spot where people should be reaching for such things.