### PR TITLE
Better interface for ConstEq

### DIFF
--- a/ambiata-tinfoil.cabal
+++ b/ambiata-tinfoil.cabal
@@ -18,6 +18,7 @@ library
                      , ambiata-p
                      , base16-bytestring               == 0.1.1.*
                      , base64-bytestring               == 1.0.0.*
+                     , binary                          >= 0.5 && < 0.9
                      , bytestring                      >= 0.10.4     && < 0.11
                      , cryptonite                      == 0.15
                      , deepseq-generics                == 0.2.0.*

--- a/src/Tinfoil/Data/Hash.hs
+++ b/src/Tinfoil/Data/Hash.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
 module Tinfoil.Data.Hash(
     Hash(..)
   , HashFunction(..)

--- a/src/Tinfoil/Data/KDF.hs
+++ b/src/Tinfoil/Data/KDF.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
 module Tinfoil.Data.KDF(
     Credential(..)
   , CredentialHash(..)

--- a/src/Tinfoil/Data/Key.hs
+++ b/src/Tinfoil/Data/Key.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
 module Tinfoil.Data.Key(
     Ed25519
   , PublicKey(..)

--- a/src/Tinfoil/Data/MAC.hs
+++ b/src/Tinfoil/Data/MAC.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Tinfoil.Data.MAC(
     KeyedHashFunction(..)
   , MAC(..)
@@ -13,6 +14,7 @@ module Tinfoil.Data.MAC(
 
 import           Control.DeepSeq.Generics (genericRnf)
 
+import           Data.Binary (Binary)
 import           Data.ByteString (ByteString)
 
 import           GHC.Generics (Generic)
@@ -28,12 +30,9 @@ import           Tinfoil.Encode
 newtype MAC =
   MAC {
     unMAC :: ByteString
-  } deriving (Show, Generic)
+  } deriving (Show, Generic, Binary, ConstEq)
 
 instance NFData MAC where rnf = genericRnf
-
-instance ConstEq MAC where
-  renderConstEq = unMAC
 
 -- | Hexadecimal encoding of a MAC.
 renderMAC :: MAC -> Text

--- a/src/Tinfoil/Data/MAC.hs
+++ b/src/Tinfoil/Data/MAC.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
 module Tinfoil.Data.MAC(
     KeyedHashFunction(..)
   , MAC(..)

--- a/src/Tinfoil/Data/Random.hs
+++ b/src/Tinfoil/Data/Random.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
 module Tinfoil.Data.Random(
     Entropy(..)
 ) where

--- a/src/Tinfoil/Data/Signing.hs
+++ b/src/Tinfoil/Data/Signing.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
 module Tinfoil.Data.Signing(
     Signature(..)
   , SignatureAlgorithm(..)

--- a/src/Tinfoil/Data/Token.hs
+++ b/src/Tinfoil/Data/Token.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
 module Tinfoil.Data.Token(
     SecureToken (..)
   , secureTokenLength


### PR DESCRIPTION
Now that I'm actually trying to use it it's a bit painful. Think this is a bit nicer. It does raise the question of broken `binary` instances also breaking the associated `ConstEq` instances, but that's the kind of thing which would be picked up by tests.

Also build data modules with `-funbox-strict-fields` because I forgot to add it earlier.

@markhibberd /cc @erikd-ambiata @thumphries 