### PR TITLE
Remove SecureToken Eq instance

### DIFF
--- a/src/Tinfoil/Data/Token.hs
+++ b/src/Tinfoil/Data/Token.hs
@@ -18,7 +18,7 @@ import           P
 newtype SecureToken =
   SecureToken {
       unSecureToken :: Text
-    } deriving (Eq, Show, Generic)
+    } deriving (Show, Generic)
 
 instance NFData SecureToken where rnf = genericRnf
 


### PR DESCRIPTION
Reasoning in #55. Happy to implement a `ConstEq` instance after #56 is in.

@markhibberd @nhibberd 