### PR TITLE
Remove orphan Show instances

### DIFF
--- a/src/Tinfoil/Data/Key.hs
+++ b/src/Tinfoil/Data/Key.hs
@@ -22,6 +22,8 @@ import           GHC.Generics (Generic)
 
 import           P
 
+import           GHC.Show (appPrec, appPrec1)
+
 import           Tinfoil.Encode
 
 -- | A cryptographically-random string of bits. A 'SymmetricKey' is 32
@@ -32,7 +34,15 @@ newtype SymmetricKey =
     unSymmetricKey :: ByteString
   } deriving (Eq, Generic)
 
-instance NFData SymmetricKey where rnf = genericRnf
+instance NFData SymmetricKey where
+  rnf = genericRnf
+
+-- | We use fixed valid Haskell tokens here to help prevent accidents such as
+-- inadvertantly logging secret keys.
+instance Show SymmetricKey where
+  showsPrec p _ =
+    showParen (p > appPrec) $
+      showString "SymmetricKey " . showsPrec appPrec1 ("redacted" :: ByteString)
 
 symmetricKeyLength :: Int
 symmetricKeyLength = 32
@@ -62,3 +72,8 @@ instance Eq (SecretKey a) where
 
 instance NFData (SecretKey a) where
   rnf (SKey_Ed25519 x) = rnf x
+
+instance Show (SecretKey a) where
+  showsPrec p (SKey_Ed25519 _) =
+    showParen (p > appPrec) $
+      showString "SKey_Ed25519 " . showsPrec appPrec1 ("redacted" :: ByteString)

--- a/test/Test/Tinfoil/Arbitrary.hs
+++ b/test/Test/Tinfoil/Arbitrary.hs
@@ -74,10 +74,6 @@ instance Arbitrary SymmetricKey where
     pure . SymmetricKey $ BS.pack xs
 
 -- Unsafe, test code only.
-instance Show SymmetricKey where
-  show (SymmetricKey x) = "SymmetricKey " <> show x
-
--- Unsafe, test code only.
 instance Eq MAC where
   (MAC a) == (MAC b) = a == b
 

--- a/test/Test/Tinfoil/Data/Key.hs
+++ b/test/Test/Tinfoil/Data/Key.hs
@@ -5,6 +5,9 @@
 
 module Test.Tinfoil.Data.Key where
 
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BSC
+
 import           Disorder.Core.Tripping (tripping)
 
 import           P
@@ -18,6 +21,10 @@ import           Test.Tinfoil.Arbitrary ()
 
 prop_tripping_SymmetricKey :: SymmetricKey -> Property
 prop_tripping_SymmetricKey = tripping renderSymmetricKey parseSymmetricKey
+
+prop_show_SymmetricKey :: SymmetricKey -> Property
+prop_show_SymmetricKey sk@(SymmetricKey bs) =
+  counterexample (show sk) $ not . BS.isInfixOf bs . BSC.pack $ show sk
 
 return []
 tests :: IO Bool


### PR DESCRIPTION
Implementing suggestion from https://github.com/ambiata/zodiac/issues/73 - we want Show instances for tests, but don't want orphans in the testing packages, and I don't want derived Show instances due to paranoia, so the solution we settled on as least-bad was to break the `read . show = id` property but get rid of orphans from the test package. This change will bubble up through `zodiac` to `ambiata-cli` et cetera.

! @markhibberd 
