### PR TITLE
Update ed25519 sigs to use detached API from new libsodium

### DIFF
--- a/src/Tinfoil/Signing/Ed25519.hs
+++ b/src/Tinfoil/Signing/Ed25519.hs
@@ -10,7 +10,6 @@ module Tinfoil.Signing.Ed25519 (
 ) where
 
 import           Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
 
 import           P
 
@@ -21,13 +20,11 @@ import           Tinfoil.Signing.Ed25519.Internal
 
 -- | Generate a detached Ed25519 signature of a message.
 signMessage :: SecretKey Ed25519 -> ByteString -> Maybe' (Signature Ed25519)
-signMessage sk msg = do
-  sm <- signMessage' sk msg
-  pure . Sig_Ed25519 $ BS.take maxSigLen sm
+signMessage sk msg =
+  Sig_Ed25519 <$> signMessage' sk msg
 
 -- | Verify a detached Ed25519 signature of a message.
 verifyMessage :: PublicKey Ed25519 -> Signature Ed25519 -> ByteString -> Verified
 verifyMessage pk (Sig_Ed25519 sig) msg =
-  let sm = sig <> msg in
-  verifyMessage' pk sm
+  verifyMessage' pk sig msg
 

--- a/test/Test/IO/Tinfoil/Signing/Ed25519/Internal.hs
+++ b/test/Test/IO/Tinfoil/Signing/Ed25519/Internal.hs
@@ -32,16 +32,15 @@ prop_genKeyPair = testIO $ do
   (pk2, sk2) <- genKeyPair
   pure $ (pk1 == pk2, sk1 == sk2) === (False, False)
 
--- Check the signed-message construction works how we think it does.
+-- Roundtrip test on the raw bindings.
 prop_signMessage' :: ByteString -> Property
 prop_signMessage' msg = testIO $ do
-  (_pk, sk) <- genKeyPair
-  case signMessage' sk msg of
+  (pk, sk) <- genKeyPair
+  pure $ case signMessage' sk msg of
     Nothing' ->
-      pure . failWith $ "Unexpected failure signing: " <> T.pack (show msg)
-    Just' sm ->
-      let msg' = BS.drop maxSigLen sm in
-      pure $ msg === msg'
+      failWith $ "Unexpected failure signing: " <> T.pack (show msg)
+    Just' sig ->
+      (verifyMessage' pk sig msg) === Verified
 
 return []
 tests :: IO Bool


### PR DESCRIPTION
The detached versions of these functions were not present in 0.4.5, so
we cut the signature off the head of the signed message to
simulate (less than ideal).

Given we no longer need to verify that our signed-message-munging works correctly, I have replaced that test with a roundtrip (sign-and-verify) test.

Also, this replaces the non-detached bindings; I don't want unused functionality lying around accumulating bitrot.

! @erikd-ambiata @novemberkilo @thumphries