### PR TITLE
Sodium initialisation bindings

### DIFF
--- a/ambiata-tinfoil.cabal
+++ b/ambiata-tinfoil.cabal
@@ -50,6 +50,8 @@ library
                        Tinfoil.Data.Verify
                        Tinfoil.Encode
                        Tinfoil.Hash
+                       Tinfoil.Internal.Sodium.Data
+                       Tinfoil.Internal.Sodium.Foreign
                        Tinfoil.KDF
                        Tinfoil.KDF.Scrypt
                        Tinfoil.KDF.Scrypt.Internal

--- a/ambiata-tinfoil.cabal
+++ b/ambiata-tinfoil.cabal
@@ -78,7 +78,7 @@ library
 
   cc-options:
                        -- x86 extensions
-                       -msse2
+                       -msse3
 
                        -- Warnings.
                        -Waggregate-return

--- a/src/Tinfoil/Internal/Sodium/Data.hs
+++ b/src/Tinfoil/Internal/Sodium/Data.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Tinfoil.Internal.Sodium.Data (
+    SodiumInitStatus(..)
+  ) where
+
+import           P
+
+data SodiumInitStatus =
+    SodiumInitialised
+  | SodiumNotInitialised
+  deriving (Eq, Show, Enum, Bounded)

--- a/src/Tinfoil/Internal/Sodium/Foreign.hs
+++ b/src/Tinfoil/Internal/Sodium/Foreign.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Tinfoil.Internal.Sodium.Foreign (
+    sodiumInit
+  ) where
+
+import           Foreign.C (CInt(..))
+
+import           P
+
+import           System.IO (IO)
+
+import           Tinfoil.Internal.Sodium.Data
+
+-- |
+-- Performs global init stuff in the C library. Some libsodium functionality
+-- can be used without this function being called, but will generally result
+-- in loss of thread-safety - in other words, don't do it.
+--
+-- This function is thread-safe and idempotent.
+foreign import ccall safe "sodium_init" sodium_init
+  :: IO CInt
+
+sodiumInit :: IO SodiumInitStatus
+sodiumInit =
+  sodium_init >>= \x -> case x of
+    0 -> pure SodiumInitialised -- init succeeded
+    1 -> pure SodiumInitialised -- already initialised
+    _ -> pure SodiumNotInitialised
+

--- a/test/Test/IO/Tinfoil/Internal/Sodium/Foreign.hs
+++ b/test/Test/IO/Tinfoil/Internal/Sodium/Foreign.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.IO.Tinfoil.Internal.Sodium.Foreign where
+
+import           Disorder.Core.IO (testIO)
+
+import           P
+
+import           System.IO
+
+import           Test.QuickCheck
+
+import           Tinfoil.Internal.Sodium.Data
+import           Tinfoil.Internal.Sodium.Foreign
+
+prop_sodiumInit :: Property
+prop_sodiumInit = once . testIO $ do
+  r1 <- sodiumInit
+  r2 <- sodiumInit
+  pure $ (r1, r2) === (SodiumInitialised, SodiumInitialised)
+
+return []
+tests :: IO Bool
+tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 1000 } )

--- a/test/test-io.hs
+++ b/test/test-io.hs
@@ -3,6 +3,7 @@ import           Disorder.Core.Main
 import qualified Test.IO.Tinfoil.Comparison
 import qualified Test.IO.Tinfoil.Data.MAC
 import qualified Test.IO.Tinfoil.Hash
+import qualified Test.IO.Tinfoil.Internal.Sodium.Foreign
 import qualified Test.IO.Tinfoil.KDF
 import qualified Test.IO.Tinfoil.KDF.Scrypt
 import qualified Test.IO.Tinfoil.KDF.Scrypt.Compat
@@ -17,6 +18,7 @@ main =
     Test.IO.Tinfoil.Comparison.tests
   , Test.IO.Tinfoil.Data.MAC.tests
   , Test.IO.Tinfoil.Hash.tests
+  , Test.IO.Tinfoil.Internal.Sodium.Foreign.tests
   , Test.IO.Tinfoil.KDF.tests
   , Test.IO.Tinfoil.KDF.Scrypt.tests
   , Test.IO.Tinfoil.KDF.Scrypt.Compat.tests


### PR DESCRIPTION
Plus build with SSE3, because why not (we're about to add functionality which relies on AESNI, and if we have that we must have at least SSE3).

! @erikd-ambiata @thumphries 