### PR TITLE
Add sodium init with marker type

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lib/libsodium"]
 	path = lib/libsodium
 	url = https://github.com/ambiata/libsodium
+[submodule "lib/x"]
+	path = lib/x
+	url = https://github.com/ambiata/x

--- a/ambiata-tinfoil.cabal
+++ b/ambiata-tinfoil.cabal
@@ -16,6 +16,7 @@ library
   build-depends:
                        base                            >= 3          && < 5
                      , ambiata-p
+                     , ambiata-x-eithert
                      , base16-bytestring               == 0.1.1.*
                      , base64-bytestring               == 1.0.0.*
                      , binary                          >= 0.5 &&     < 0.9
@@ -50,6 +51,7 @@ library
                        Tinfoil.Data.Verify
                        Tinfoil.Encode
                        Tinfoil.Hash
+                       Tinfoil.Internal.Sodium
                        Tinfoil.Internal.Sodium.Data
                        Tinfoil.Internal.Sodium.Foreign
                        Tinfoil.KDF

--- a/ambiata-tinfoil.cabal
+++ b/ambiata-tinfoil.cabal
@@ -150,6 +150,7 @@ test-suite test-io
                      , ambiata-disorder-core
                      , ambiata-disorder-corpus
                      , ambiata-p
+                     , ambiata-x-eithert
                      , bytestring                      >= 0.10.4     && < 0.11
                      , QuickCheck                      >= 2.7 &&     < 2.9
                      , quickcheck-instances            == 0.3.*

--- a/src/Tinfoil/Internal/Sodium.hs
+++ b/src/Tinfoil/Internal/Sodium.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Tinfoil.Internal.Sodium (
+    SodiumError(..)
+  , SodiumInitMarker
+  , initialiseSodium
+  ) where
+
+import           Control.Monad.IO.Class (liftIO)
+
+import           P
+
+import           System.IO (IO)
+
+import           Tinfoil.Internal.Sodium.Data
+import qualified Tinfoil.Internal.Sodium.Foreign as F
+
+import           X.Control.Monad.Trans.Either (EitherT, left)
+
+data SodiumError =
+    SodiumInitFailed
+  | NoAESGCMCPUSupport
+  deriving (Eq, Show)
+
+-- | Marker type indicating that the sodium C library has been
+-- successfully initialised. Every function which calls out to
+-- libsodium should require this as an argument.
+data SodiumInitMarker =
+    -- | `sodium_init()` has been called successfully, and we're running on a
+    -- CPU which meets our requirements (aesni).
+    SodiumIsInitialised
+  deriving (Eq, Show)
+
+-- | Perform required initialisation required for the sodium C library. This
+-- includes ensuring we have hardware support for aes-gcm (can't run safely
+-- without it).
+--
+-- This function must be called before calling out to anything else in
+-- libsodium.
+initialiseSodium :: EitherT SodiumError IO SodiumInitMarker
+initialiseSodium =
+  (liftIO F.sodiumInit) >>= \x -> case x of
+    SodiumInitialised ->
+      (liftIO F.aesgcmSupported) >>= \y -> case y of
+        AESGCMSupported ->
+          pure SodiumIsInitialised
+        AESGCMNotSupported ->
+          left NoAESGCMCPUSupport
+    SodiumNotInitialised ->
+      left SodiumInitFailed

--- a/src/Tinfoil/Internal/Sodium/Data.hs
+++ b/src/Tinfoil/Internal/Sodium/Data.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Tinfoil.Internal.Sodium.Data (
     SodiumInitStatus(..)
+  , AESGCMSupport(..)
   ) where
 
 import           P
@@ -11,3 +12,9 @@ data SodiumInitStatus =
     SodiumInitialised
   | SodiumNotInitialised
   deriving (Eq, Show, Enum, Bounded)
+
+data AESGCMSupport =
+    AESGCMSupported
+  | AESGCMNotSupported
+  deriving (Eq, Show, Enum, Bounded)
+

--- a/test/Test/IO/Tinfoil/Internal/Sodium.hs
+++ b/test/Test/IO/Tinfoil/Internal/Sodium.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.IO.Tinfoil.Internal.Sodium where
+
+import           Disorder.Core.IO (testIO)
+
+import           P
+
+import           System.IO
+
+import           Test.QuickCheck
+
+import           Tinfoil.Internal.Sodium
+
+import           X.Control.Monad.Trans.Either (runEitherT)
+
+prop_initialiseSodium :: Property
+prop_initialiseSodium = once . testIO $ do
+  r1 <- runEitherT initialiseSodium
+  r2 <- runEitherT initialiseSodium
+  pure $ (r1, isRight r1, isRight r2) === (r2, True, True)
+
+return []
+tests :: IO Bool
+tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 1000 } )

--- a/test/Test/IO/Tinfoil/Internal/Sodium/Foreign.hs
+++ b/test/Test/IO/Tinfoil/Internal/Sodium/Foreign.hs
@@ -19,6 +19,12 @@ prop_sodiumInit = once . testIO $ do
   r2 <- sodiumInit
   pure $ (r1, r2) === (SodiumInitialised, SodiumInitialised)
 
+prop_aesgcmSupported :: Property
+prop_aesgcmSupported = once . testIO $ do
+  void sodiumInit
+  r1 <- aesgcmSupported
+  pure $ r1 === AESGCMSupported
+
 return []
 tests :: IO Bool
 tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 1000 } )

--- a/test/test-io.hs
+++ b/test/test-io.hs
@@ -3,6 +3,7 @@ import           Disorder.Core.Main
 import qualified Test.IO.Tinfoil.Comparison
 import qualified Test.IO.Tinfoil.Data.MAC
 import qualified Test.IO.Tinfoil.Hash
+import qualified Test.IO.Tinfoil.Internal.Sodium
 import qualified Test.IO.Tinfoil.Internal.Sodium.Foreign
 import qualified Test.IO.Tinfoil.KDF
 import qualified Test.IO.Tinfoil.KDF.Scrypt
@@ -18,6 +19,7 @@ main =
     Test.IO.Tinfoil.Comparison.tests
   , Test.IO.Tinfoil.Data.MAC.tests
   , Test.IO.Tinfoil.Hash.tests
+  , Test.IO.Tinfoil.Internal.Sodium.tests
   , Test.IO.Tinfoil.Internal.Sodium.Foreign.tests
   , Test.IO.Tinfoil.KDF.tests
   , Test.IO.Tinfoil.KDF.Scrypt.tests


### PR DESCRIPTION
As discussed in #77, this is an alternative implementation without the need
for a monad to ensure init happens before any other functionality is called.

! @erikd-ambiata @thumphries @charleso