### PR TITLE
aes-gcm: add IV types

### DIFF
--- a/ambiata-tinfoil.cabal
+++ b/ambiata-tinfoil.cabal
@@ -39,6 +39,8 @@ library
                        Paths_ambiata_tinfoil
                        Tinfoil
                        Tinfoil.AEAD.AESGCM.Constraints
+                       Tinfoil.AEAD.AESGCM.Data
+                       Tinfoil.AEAD.AESGCM.Iv
                        Tinfoil.Comparison
                        Tinfoil.Data
                        Tinfoil.Data.Hash

--- a/src/Tinfoil/AEAD/AESGCM/Data.hs
+++ b/src/Tinfoil/AEAD/AESGCM/Data.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
+
+module Tinfoil.AEAD.AESGCM.Data (
+    GcmIv(..)
+
+  , FixedField(..)
+
+  , InvocationField(..)
+  , RandomField(..)
+  , InvocationCount(..)
+  ) where
+
+import            Data.Word (Word32)
+
+import            P
+
+-- | This is a truncated hash identifying the context of encryption - machine
+-- and target file.
+newtype FixedField =
+  FixedField {
+    unFixedField :: Word32
+  } deriving (Eq, Show, Ord, Num, Bounded)
+
+-- | Four random bytes from a CSPRNG.
+newtype RandomField =
+  RandomField {
+    unRandomField :: Word32
+  } deriving (Eq, Show)
+
+-- | Number of invocations of the encryption function with the same key since
+-- startup.
+newtype InvocationCount =
+  InvocationCount {
+    unInvocationCount :: Integer
+  } deriving (Eq, Show, Ord, Num)
+
+-- | This identifies the operation relative to the context. It consists of
+-- a random value (32b) and an incrementing counter (32b).
+data InvocationField =
+    InvocationField !RandomField !InvocationCount
+  deriving (Eq, Show)
+
+-- | IV/nonce for GCM. 96 bits in total. Must never repeat with the same key.
+data GcmIv =
+    GcmIv !FixedField !InvocationField
+  deriving (Eq, Show)

--- a/src/Tinfoil/AEAD/AESGCM/Iv.hs
+++ b/src/Tinfoil/AEAD/AESGCM/Iv.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Tinfoil.AEAD.AESGCM.Iv (
+  ) where


### PR DESCRIPTION
Datatypes for the AES-GCM IV. These will be rendered to one Word32 and one
Word64 before being passed to libsodium.

! @markhibberd @thumphries