### PR TITLE
Fix libsodium includes

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -30,6 +30,7 @@ main =
        -- This is needed on configure to generate `version.h` so our includes
        -- don't break.
        cwd <- getCurrentDirectory
+       callProcess "git" ["submodule", "update", "--init", "lib/libsodium"]
        setCurrentDirectory $ cwd </> "lib" </> "libsodium"
        callProcess "./configure" []
        setCurrentDirectory cwd

--- a/ambiata-tinfoil.cabal
+++ b/ambiata-tinfoil.cabal
@@ -104,7 +104,7 @@ library
 
   include-dirs:        cbits/scrypt
                      , cbits/tinfoil
-                     , gen/libsodium/include
+                     , lib/libsodium/src/libsodium/include
 
   includes:            crypto_scrypt.h
                      , tinfoil.h

--- a/ambiata-tinfoil.cabal
+++ b/ambiata-tinfoil.cabal
@@ -104,6 +104,7 @@ library
 
   include-dirs:        cbits/scrypt
                      , cbits/tinfoil
+                     , gen/libsodium/include
                      , lib/libsodium/src/libsodium/include
 
   includes:            crypto_scrypt.h


### PR DESCRIPTION
Build was breaking on machines without (some version of) libsodium installed; the includes hadn't been updated after we switched to building a static library.

Fixes #86.

/cc @raronson 

! @markhibberd @erikd-ambiata 
/jury approve @markhibberd