### PR TITLE
Read entropy directly from urandom

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,10 @@ Thread safety
 
 All functions in `tinfoil` are thread-safe unless explicitly noted
 otherwise in the function's documentation.
+
+Platform support
+----------------
+
+`tinfoil` explicitly supports Linux and OS X. It may run on other
+unixlike systems, but may also break or violate the behavioural
+invariants described above.

--- a/ambiata-tinfoil.cabal
+++ b/ambiata-tinfoil.cabal
@@ -28,6 +28,7 @@ library
                      , semigroups                      >= 0.16       && < 0.19
                      , text                            == 1.2.*
                      , transformers                    >= 0.3        && < 0.6
+                     , unix                            == 2.7.*
 
   ghc-options:
                        -Wall

--- a/src/Tinfoil/Random/Internal.hs
+++ b/src/Tinfoil/Random/Internal.hs
@@ -6,6 +6,7 @@ module Tinfoil.Random.Internal(
   , readBitsLE
   , dropMS
   , segmentsOf
+  , urandom
 ) where
 
 import           Data.Bits
@@ -13,6 +14,9 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 
 import           P
+
+import           System.IO (IOMode(..), IO)
+import           System.IO (withFile)
 
 segmentsOf :: Int -> [a] -> [[a]]
 segmentsOf _ [] = []
@@ -33,3 +37,20 @@ readBitsLE = foldr' pack 0
 
 explodeBS :: ByteString -> [Bool]
 explodeBS = concatMap (\w -> testBit w <$> [0..7]) . BS.unpack
+
+-- |
+-- Read entropy from /dev/urandom.
+--
+-- On OS X this calls a 160-bit Yarrow generator and will block until
+-- the entropy pool has been initialised (should never happen); on
+-- Linux it is a sha1-based generator and will not block regardless of
+-- pool state.
+--
+-- This function incurs some overhead due to GHC.IO buffering; if this
+-- becomes significant (e.g., key generation), using read(3) directly
+-- would make small reads significantly faster.
+--
+-- FIXME: is it worth checking uname and failing on non-linux/darwin here?
+urandom :: Int -> IO ByteString
+urandom n =
+  withFile "/dev/urandom" ReadMode (\h -> BS.hGet h n)

--- a/test/Test/IO/Tinfoil/Random.hs
+++ b/test/Test/IO/Tinfoil/Random.hs
@@ -15,6 +15,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 
 import           Disorder.Core.IO
+import           Disorder.Core.Property ((=/=))
 
 import           P
 
@@ -22,6 +23,7 @@ import           System.IO
 
 import           Tinfoil.Data
 import           Tinfoil.Random
+import           Tinfoil.Random.Internal
 
 import           Test.QuickCheck
 import           Test.Tinfoil.Arbitrary ()
@@ -51,6 +53,23 @@ prop_drawOnce_closure :: Property
 prop_drawOnce_closure = forAll arbitrary $ \(xs :: NonEmpty Int) -> testIO $ do
   x <- drawOnce xs
   pure $ elem x xs
+
+mi :: Int
+mi =
+  1024 * 1024
+
+prop_urandom_length :: Property
+prop_urandom_length =
+  forAll (choose (0, 10 * mi)) $ \n -> testIO $ do
+    bs <- urandom n
+    pure $ BS.length bs === n
+
+prop_urandom_neq :: Property
+prop_urandom_neq =
+  forAll (choose (128, 10 * mi)) $ \n -> testIO $ do
+    bs1 <- urandom n
+    bs2 <- urandom n
+    pure $ bs1 =/= bs2
 
 return []
 tests :: IO Bool

--- a/test/bench.hs
+++ b/test/bench.hs
@@ -29,6 +29,7 @@ import           Tinfoil.Hash
 import qualified Tinfoil.KDF.Scrypt as Scrypt
 import           Tinfoil.MAC
 import           Tinfoil.Random
+import           Tinfoil.Random.Internal
 import qualified Tinfoil.Signing.Ed25519 as Ed25519
 
 generate' :: Gen a -> IO a
@@ -80,10 +81,13 @@ main = tinfoilBench [
       , bench "1000" $ nfIO (randomCredential [] 1000)
       , bench "100000" $ nfIO (randomCredential [] 100000)
       ]
-  , bgroup "entropy" $
-      [ bench "Tinfoil.Random.entropy/1" $ nfIO (entropy 1)
+  , bgroup "entropy" $ [
+        bench "Tinfoil.Random.entropy/1" $ nfIO (entropy 1)
       , bench "Tinfoil.Random.entropy/1000" $ nfIO (entropy 1000)
       , bench "Tinfoil.Random.entropy/100000" $ nfIO (entropy 100000)
+      , bench "Tinfoil.Random.Internal.urandom/1" $ nfIO (urandom 1)
+      , bench "Tinfoil.Random.Internal.urandom/1000" $ nfIO (urandom 1000)
+      , bench "Tinfoil.Random.Internal.urandom/100000" $ nfIO (urandom 100000)
       , bench "System.Random.StdRandom/1" $ nfIO (stdRandom 1)
       , bench "System.Random.StdRandom/1000" $ nfIO (stdRandom 1000)
       , bench "System.Random.StdRandom/100000" $ nfIO (stdRandom 100000)

--- a/test/bench.hs
+++ b/test/bench.hs
@@ -83,10 +83,16 @@ main = tinfoilBench [
       ]
   , bgroup "entropy" $ [
         bench "Tinfoil.Random.entropy/1" $ nfIO (entropy 1)
+      , bench "Tinfoil.Random.entropy/10" $ nfIO (entropy 10)
+      , bench "Tinfoil.Random.entropy/100" $ nfIO (entropy 100)
       , bench "Tinfoil.Random.entropy/1000" $ nfIO (entropy 1000)
+      , bench "Tinfoil.Random.entropy/10000" $ nfIO (entropy 10000)
       , bench "Tinfoil.Random.entropy/100000" $ nfIO (entropy 100000)
       , bench "Tinfoil.Random.Internal.urandom/1" $ nfIO (urandom 1)
+      , bench "Tinfoil.Random.Internal.urandom/10" $ nfIO (urandom 10)
+      , bench "Tinfoil.Random.Internal.urandom/100" $ nfIO (urandom 100)
       , bench "Tinfoil.Random.Internal.urandom/1000" $ nfIO (urandom 1000)
+      , bench "Tinfoil.Random.Internal.urandom/10000" $ nfIO (urandom 10000)
       , bench "Tinfoil.Random.Internal.urandom/100000" $ nfIO (urandom 100000)
       , bench "System.Random.StdRandom/1" $ nfIO (stdRandom 1)
       , bench "System.Random.StdRandom/1000" $ nfIO (stdRandom 1000)


### PR DESCRIPTION
Initial PR adds this alongside the `System.Entropy` implementation. The internal version is slower than `System.Entropy` for small reads (up to ~1KiB) by around a factor of ten and then significantly faster for reads larger than this. The overhead (~40 microseconds on my laptop) is the read buffering in `GHC.IO`; I'm not sure if it's worth bothering with at this point but it's a simple fix.

This is pretty much the dumbest possible implementation and doesn't make any attempt to sanity-check the platform (i.e., fail if we're running on something other than linux/osx/freebsd/etc); would appreciate your thoughts on this, though again it's probably not a big deal.

! @erikd-ambiata @markhibberd 