### PR TITLE
Read directly from urandom to bypass GHC read buffering

### DIFF
--- a/ambiata-tinfoil.cabal
+++ b/ambiata-tinfoil.cabal
@@ -28,6 +28,7 @@ library
                      , semigroups                      >= 0.16       && < 0.19
                      , text                            == 1.2.*
                      , transformers                    >= 0.3        && < 0.6
+                     , unix                            == 2.7.*
 
   ghc-options:
                        -Wall


### PR DESCRIPTION
This avoids buffering overhead which is significant for small reads.

Alternative to implementation in #98. Note that we explicitly throw an
exception here, but this is the same behaviour we'd get from using
`BS.hGet` as we do in #98.

Benchmarks incoming.

! @erikd-ambiata @markhibberd
/jury approved @erikd-ambiata